### PR TITLE
Substitution uses map instead of assoc list

### DIFF
--- a/micro/derived.gen.go
+++ b/micro/derived.gen.go
@@ -4,6 +4,7 @@ package micro
 
 import (
 	ast "github.com/awalterschulze/gominikanren/sexpr/ast"
+	"sort"
 )
 
 // deriveTupleO returns a function, which returns the input values.
@@ -38,6 +39,31 @@ func deriveTuple3S(v0 string, v1 Substitutions, v2 string) func() (string, Subst
 	}
 }
 
+// deriveClone returns a clone of the src parameter.
+func deriveClone(src Substitutions) Substitutions {
+	if src == nil {
+		return nil
+	}
+	dst := make(Substitutions)
+	deriveDeepCopy(dst, src)
+	return dst
+}
+
+// deriveSorted sorts the slice inplace and also returns it.
+func deriveSorted(list []string) []string {
+	sort.Strings(list)
+	return list
+}
+
+// deriveKeys returns the keys of the input map as a slice.
+func deriveKeys(m map[string]*ast.SExpr) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 // deriveFmapRs returns a list where each element of the input list has been morphed by the input function.
 func deriveFmapRs(f func(*State) *ast.SExpr, list []*State) []*ast.SExpr {
 	out := make([]*ast.SExpr, len(list))
@@ -54,4 +80,85 @@ func deriveFmaps(f func(*State) string, list []*State) []string {
 		out[i] = f(elem)
 	}
 	return out
+}
+
+// deriveDeepCopy recursively copies the contents of src into dst.
+func deriveDeepCopy(dst, src Substitutions) {
+	for src_key, src_value := range src {
+		if src_value == nil {
+			dst[src_key] = nil
+		}
+		if src_value == nil {
+			dst[src_key] = nil
+		} else {
+			dst[src_key] = new(ast.SExpr)
+			deriveDeepCopy_(dst[src_key], src_value)
+		}
+	}
+}
+
+// deriveDeepCopy_ recursively copies the contents of src into dst.
+func deriveDeepCopy_(dst, src *ast.SExpr) {
+	if src.Pair == nil {
+		dst.Pair = nil
+	} else {
+		dst.Pair = new(ast.Pair)
+		deriveDeepCopy_1(dst.Pair, src.Pair)
+	}
+	if src.Atom == nil {
+		dst.Atom = nil
+	} else {
+		dst.Atom = new(ast.Atom)
+		deriveDeepCopy_2(dst.Atom, src.Atom)
+	}
+}
+
+// deriveDeepCopy_1 recursively copies the contents of src into dst.
+func deriveDeepCopy_1(dst, src *ast.Pair) {
+	if src.Car == nil {
+		dst.Car = nil
+	} else {
+		dst.Car = new(ast.SExpr)
+		deriveDeepCopy_(dst.Car, src.Car)
+	}
+	if src.Cdr == nil {
+		dst.Cdr = nil
+	} else {
+		dst.Cdr = new(ast.SExpr)
+		deriveDeepCopy_(dst.Cdr, src.Cdr)
+	}
+}
+
+// deriveDeepCopy_2 recursively copies the contents of src into dst.
+func deriveDeepCopy_2(dst, src *ast.Atom) {
+	if src.Str == nil {
+		dst.Str = nil
+	} else {
+		dst.Str = new(string)
+		*dst.Str = *src.Str
+	}
+	if src.Symbol == nil {
+		dst.Symbol = nil
+	} else {
+		dst.Symbol = new(string)
+		*dst.Symbol = *src.Symbol
+	}
+	if src.Float == nil {
+		dst.Float = nil
+	} else {
+		dst.Float = new(float64)
+		*dst.Float = *src.Float
+	}
+	if src.Int == nil {
+		dst.Int = nil
+	} else {
+		dst.Int = new(int64)
+		*dst.Int = *src.Int
+	}
+	if src.Var == nil {
+		dst.Var = nil
+	} else {
+		dst.Var = new(ast.Variable)
+		*dst.Var = *src.Var
+	}
 }

--- a/micro/derived.gen.go
+++ b/micro/derived.gen.go
@@ -38,15 +38,6 @@ func deriveTuple3S(v0 string, v1 Substitutions, v2 string) func() (string, Subst
 	}
 }
 
-// deriveFmapSs returns a list where each element of the input list has been morphed by the input function.
-func deriveFmapSs(f func(*Substitution) *ast.SExpr, list []*Substitution) []*ast.SExpr {
-	out := make([]*ast.SExpr, len(list))
-	for i, elem := range list {
-		out[i] = f(elem)
-	}
-	return out
-}
-
 // deriveFmapRs returns a list where each element of the input list has been morphed by the input function.
 func deriveFmapRs(f func(*State) *ast.SExpr, list []*State) []*ast.SExpr {
 	out := make([]*ast.SExpr, len(list))

--- a/micro/exts.go
+++ b/micro/exts.go
@@ -30,7 +30,12 @@ func exts(x *ast.Variable, v *ast.SExpr, s Substitutions) (Substitutions, bool) 
 	if occurs(x, v, s) {
 		return nil, false
 	}
-	return append([]*Substitution{&Substitution{Var: x.Name, Value: v}}, s...), true
+    m := map[string]*ast.SExpr{}
+    for key, value := range s {
+        m[key] = value
+    }
+    m[x.Name] = v
+    return m, true
 }
 
 /*

--- a/micro/exts.go
+++ b/micro/exts.go
@@ -30,9 +30,9 @@ func exts(x *ast.Variable, v *ast.SExpr, s Substitutions) (Substitutions, bool) 
 	if occurs(x, v, s) {
 		return nil, false
 	}
-    m := map[string]*ast.SExpr{}
-    for key, value := range s {
-        m[key] = value
+    m := deriveClone(s)
+    if m == nil {
+        m = map[string]*ast.SExpr{}
     }
     m[x.Name] = v
     return m, true

--- a/micro/exts_test.go
+++ b/micro/exts_test.go
@@ -11,10 +11,9 @@ func TestOccurs(t *testing.T) {
 	tests := []func() (string, string, Substitutions, bool){
 		deriveTupleO(",x", ",x", Substitutions(nil), true),
 		deriveTupleO(",x", ",y", nil, false),
-		deriveTupleO(",x", "(,y)", Substitutions{&Substitution{
-			Var:   "y",
-			Value: ast.NewVariable("x"),
-		}}, true),
+		deriveTupleO(",x", "(,y)", Substitutions{
+            "y": ast.NewVariable("x"),
+		}, true),
 	}
 	for _, test := range tests {
 		x, v, s, want := test()
@@ -37,36 +36,24 @@ func TestOccurs(t *testing.T) {
 
 func TestExts(t *testing.T) {
 	tests := []func() (string, string, Substitutions, Substitutions){
-		deriveTupleE(",x", "a", Substitutions(nil), Substitutions{&Substitution{
-			Var:   "x",
-			Value: ast.NewSymbol("a"),
-		}}),
+		deriveTupleE(",x", "a", Substitutions(nil), Substitutions{
+			"x": ast.NewSymbol("a"),
+		}),
 		deriveTupleE(",x", "(,x)", Substitutions(nil), Substitutions(nil)),
 		deriveTupleE(",x", "(,y)",
-			Substitutions{&Substitution{
-				Var:   "y",
-				Value: ast.NewVariable("x"),
-			}},
+			Substitutions{
+				"y": ast.NewVariable("x"),
+			},
 			Substitutions(nil)),
 		deriveTupleE(",x", "e",
 			Substitutions{
-				&Substitution{
-					Var:   "z",
-					Value: ast.NewVariable("x"),
-				}, &Substitution{
-					Var:   "y",
-					Value: ast.NewVariable("z"),
-				}}, Substitutions{
-				&Substitution{
-					Var:   "x",
-					Value: ast.NewSymbol("e"),
-				}, &Substitution{
-					Var:   "z",
-					Value: ast.NewVariable("x"),
-				}, &Substitution{
-					Var:   "y",
-					Value: ast.NewVariable("z"),
+					"z": ast.NewVariable("x"),
+					"y": ast.NewVariable("z"),
 				},
+            Substitutions{
+					"x": ast.NewSymbol("e"),
+					"z": ast.NewVariable("x"),
+					"y": ast.NewVariable("z"),
 			},
 		),
 	}

--- a/micro/goal.go
+++ b/micro/goal.go
@@ -1,6 +1,7 @@
 package micro
 
 import (
+    "sort"
 	"strconv"
 
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
@@ -26,25 +27,30 @@ func EmptyState() *State {
 }
 
 // Substitutions is a list of substitutions represented by a sexprs pair.
-type Substitutions []*Substitution
+type Substitutions map[string]*ast.SExpr
 
 func (s Substitutions) String() string {
-	ss := deriveFmapSs(func(s *Substitution) *ast.SExpr {
-		return ast.Cons(&ast.SExpr{Atom: &ast.Atom{Var: &ast.Variable{Name: s.Var}}}, s.Value)
-	}, []*Substitution(s))
-	l := ast.NewList(ss...).String()
+    keys := make([]string, len(s))
+    i := 0
+    for k, _ := range s {
+        keys[i] = k
+        i++
+    }
+    sort.Strings(keys)
+    sexprs := make([]*ast.SExpr, len(s))
+    for i, k := range keys {
+        v := s[k]
+        sexprs[len(s)-1-i] = ast.Cons(&ast.SExpr{Atom: &ast.Atom{Var: &ast.Variable{Name: k}}}, v)
+    }
+    l := ast.NewList(sexprs...).String()
 	return l[1 : len(l)-1]
 }
 
-// Substitution represents a variable and a value.
-type Substitution struct {
-	Var   string
-	Value *ast.SExpr
-}
-
+/*
 func (s Substitution) String() string {
 	return ast.Cons(&ast.SExpr{Atom: &ast.Atom{Var: &ast.Variable{Name: s.Var}}}, s.Value).String()
 }
+*/
 
 // GoalFn is a function that takes a state and returns a stream of states.
 type GoalFn func(*State) StreamOfStates

--- a/micro/goal.go
+++ b/micro/goal.go
@@ -1,7 +1,6 @@
 package micro
 
 import (
-    "sort"
 	"strconv"
 
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
@@ -30,15 +29,9 @@ func EmptyState() *State {
 type Substitutions map[string]*ast.SExpr
 
 func (s Substitutions) String() string {
-    keys := make([]string, len(s))
-    i := 0
-    for k, _ := range s {
-        keys[i] = k
-        i++
-    }
-    sort.Strings(keys)
     sexprs := make([]*ast.SExpr, len(s))
-    for i, k := range keys {
+    ss := map[string]*ast.SExpr(s)
+    for i, k := range deriveSorted(deriveKeys(ss)) {
         v := s[k]
         sexprs[len(s)-1-i] = ast.Cons(&ast.SExpr{Atom: &ast.Atom{Var: &ast.Variable{Name: k}}}, v)
     }

--- a/micro/reify.go
+++ b/micro/reify.go
@@ -54,7 +54,12 @@ func reifys(v *ast.SExpr, s Substitutions) Substitutions {
 	}
 	if vv.IsVariable() {
 		n := reifyName(len(s))
-		return append([]*Substitution{&Substitution{Var: vv.Atom.Var.Name, Value: n}}, s...)
+        m := map[string]*ast.SExpr{}
+        for key, value := range s {
+            m[key] = value
+        }
+        m[vv.Atom.Var.Name] = n
+        return m
 	}
 	if vv.IsPair() {
 		car := vv.Car()

--- a/micro/reify.go
+++ b/micro/reify.go
@@ -54,9 +54,9 @@ func reifys(v *ast.SExpr, s Substitutions) Substitutions {
 	}
 	if vv.IsVariable() {
 		n := reifyName(len(s))
-        m := map[string]*ast.SExpr{}
-        for key, value := range s {
-            m[key] = value
+        m := deriveClone(s)
+        if m == nil {
+            m = map[string]*ast.SExpr{}
         }
         m[vv.Atom.Var.Name] = n
         return m

--- a/micro/reify_test.go
+++ b/micro/reify_test.go
@@ -37,18 +37,9 @@ func TestReify(t *testing.T) {
 		t.Fatal(err)
 	}
 	ss := Substitutions{
-		&Substitution{
-			Var:   "x",
-			Value: e.Car().Cdr(),
-		},
-		&Substitution{
-			Var:   "y",
-			Value: e.Cdr().Car().Cdr(),
-		},
-		&Substitution{
-			Var:   "w",
-			Value: e.Cdr().Cdr().Car().Cdr(),
-		},
+			"x": e.Car().Cdr(),
+			"y": e.Cdr().Car().Cdr(),
+			"w": e.Cdr().Cdr().Car().Cdr(),
 	}
 	if !e.IsPair() {
 		t.Fatalf("expected list")

--- a/micro/walk.go
+++ b/micro/walk.go
@@ -18,14 +18,14 @@ walk has been modified to assume it is getting a variable, but here is the origi
 	)
 */
 func walk(v *ast.Variable, s Substitutions) *ast.SExpr {
-	a, ok := assv(v, s)
+	value, ok := assv(v, s)
 	if !ok {
 		return &ast.SExpr{Atom: &ast.Atom{Var: v}}
 	}
-	if !a.Value.IsVariable() {
-		return a.Value
+	if !value.IsVariable() {
+		return value
 	}
-	return walk(a.Value.Atom.Var, s)
+	return walk(value.Atom.Var, s)
 }
 
 /*
@@ -36,16 +36,15 @@ for example:
 
 	assv v s <==> (assp (λ (v) (var=? u v)) s))
 */
-func assv(v *ast.Variable, ss Substitutions) (*Substitution, bool) {
+func assv(v *ast.Variable, ss Substitutions) (*ast.SExpr, bool) {
 	if ss == nil {
 		return nil, false
 	}
-	for i, s := range ss {
-		if v.Name == s.Var {
-			return ss[i], true
-		}
-	}
-	return nil, false
+    value, ok := ss[v.Name]
+    if !ok {
+        return nil, false
+    }
+    return value, true
 }
 
 /*

--- a/micro/walk_test.go
+++ b/micro/walk_test.go
@@ -8,32 +8,14 @@ import (
 
 func TestWalk(t *testing.T) {
 	zaxwyz := Substitutions{
-		&Substitution{
-			Var:   "z",
-			Value: ast.NewSymbol("a"),
-		},
-		&Substitution{
-			Var:   "x",
-			Value: ast.NewVariable("w"),
-		},
-		&Substitution{
-			Var:   "y",
-			Value: ast.NewVariable("z"),
-		},
+			"z": ast.NewSymbol("a"),
+			"x": ast.NewVariable("w"),
+			"y": ast.NewVariable("z"),
 	}
 	xyvxwx := Substitutions{
-		&Substitution{
-			Var:   "x",
-			Value: ast.NewVariable("y"),
-		},
-		&Substitution{
-			Var:   "v",
-			Value: ast.NewVariable("x"),
-		},
-		&Substitution{
-			Var:   "w",
-			Value: ast.NewVariable("x"),
-		},
+			"x": ast.NewVariable("y"),
+			"v": ast.NewVariable("x"),
+			"w": ast.NewVariable("x"),
 	}
 	tests := []func() (string, Substitutions, string){
 		deriveTuple3S("z", zaxwyz, "a"),
@@ -43,32 +25,14 @@ func TestWalk(t *testing.T) {
 		deriveTuple3S("v", xyvxwx, ",y"),
 		deriveTuple3S("w", xyvxwx, ",y"),
 		deriveTuple3S("w", Substitutions{
-			&Substitution{
-				Var:   "x",
-				Value: ast.NewSymbol("b"),
-			},
-			&Substitution{
-				Var:   "z",
-				Value: ast.NewVariable("y"),
-			},
-			&Substitution{
-				Var:   "w",
-				Value: ast.NewList(ast.NewVariable("x"), ast.NewSymbol("e"), ast.NewVariable("z")),
-			},
+				"x": ast.NewSymbol("b"),
+				"z": ast.NewVariable("y"),
+				"w": ast.NewList(ast.NewVariable("x"), ast.NewSymbol("e"), ast.NewVariable("z")),
 		}, "(,x e ,z)"),
 		deriveTuple3S("y", Substitutions{
-			&Substitution{
-				Var:   "x",
-				Value: ast.NewSymbol("e"),
-			},
-			&Substitution{
-				Var:   "z",
-				Value: ast.NewVariable("x"),
-			},
-			&Substitution{
-				Var:   "y",
-				Value: ast.NewVariable("z"),
-			},
+				"x": ast.NewSymbol("e"),
+				"z": ast.NewVariable("x"),
+				"y": ast.NewVariable("z"),
 		}, "e"),
 	}
 	for _, test := range tests {
@@ -85,32 +49,14 @@ func TestWalk(t *testing.T) {
 
 func TestWalkStar(t *testing.T) {
 	zaxwyz := Substitutions{
-		&Substitution{
-			Var:   "z",
-			Value: ast.NewSymbol("a"),
-		},
-		&Substitution{
-			Var:   "x",
-			Value: ast.NewVariable("w"),
-		},
-		&Substitution{
-			Var:   "y",
-			Value: ast.NewVariable("z"),
-		},
+			"z": ast.NewSymbol("a"),
+			"x": ast.NewVariable("w"),
+			"y": ast.NewVariable("z"),
 	}
 	xyvxwx := Substitutions{
-		&Substitution{
-			Var:   "x",
-			Value: ast.NewVariable("y"),
-		},
-		&Substitution{
-			Var:   "v",
-			Value: ast.NewVariable("x"),
-		},
-		&Substitution{
-			Var:   "w",
-			Value: ast.NewVariable("x"),
-		},
+			"x": ast.NewVariable("y"),
+			"v": ast.NewVariable("x"),
+			"w": ast.NewVariable("x"),
 	}
 	tests := []func() (string, Substitutions, string){
 		deriveTuple3S("z", zaxwyz, "a"),
@@ -120,32 +66,14 @@ func TestWalkStar(t *testing.T) {
 		deriveTuple3S("v", xyvxwx, ",y"),
 		deriveTuple3S("w", xyvxwx, ",y"),
 		deriveTuple3S("w", Substitutions{
-			&Substitution{
-				Var:   "x",
-				Value: ast.NewSymbol("b"),
-			},
-			&Substitution{
-				Var:   "z",
-				Value: ast.NewVariable("y"),
-			},
-			&Substitution{
-				Var:   "w",
-				Value: ast.NewList(ast.NewVariable("x"), ast.NewSymbol("e"), ast.NewVariable("z")),
-			},
+				"x": ast.NewSymbol("b"),
+				"z": ast.NewVariable("y"),
+				"w": ast.NewList(ast.NewVariable("x"), ast.NewSymbol("e"), ast.NewVariable("z")),
 		}, "(b e ,y)"),
 		deriveTuple3S("y", Substitutions{
-			&Substitution{
-				Var:   "x",
-				Value: ast.NewSymbol("e"),
-			},
-			&Substitution{
-				Var:   "z",
-				Value: ast.NewVariable("x"),
-			},
-			&Substitution{
-				Var:   "y",
-				Value: ast.NewVariable("z"),
-			},
+				"x": ast.NewSymbol("e"),
+				"z": ast.NewVariable("x"),
+				"y": ast.NewVariable("z"),
 		}, "e"),
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Use a map for substitutions, which is faster in general
Especially important for very large substitutions.
Order is preserved when reified by simply sorting the keys.

For reference, see the Readme on:
https://github.com/michaelballantyne/faster-miniKanren