### PR TITLE
fix scoping issues

### DIFF
--- a/micro/conj.go
+++ b/micro/conj.go
@@ -47,7 +47,7 @@ func Bind(s StreamOfStates, g Goal) StreamOfStates {
 	}
 	car, cdr := s()
 	if car != nil { // not a suspension => procedure? == false
-		return mplus(
+		return Mplus(
 			g()(car),
 			Bind(
 				cdr,

--- a/micro/disj.go
+++ b/micro/disj.go
@@ -24,12 +24,14 @@ func DisjointO(gs ...Goal) Goal {
 		return func(s *State) StreamOfStates {
 			g1s := g1()(s)
 			g2s := g2()(s)
-			return mplus(g1s, g2s)
+			return Mplus(g1s, g2s)
 		}
 	}
 }
 
 /*
+Mplus is responsible for merging streams
+
 scheme code:
 
 	(define (mplus $1 $2)
@@ -52,17 +54,17 @@ scheme code:
 		)
 	)
 */
-func mplus(g1, g2 StreamOfStates) StreamOfStates {
+func Mplus(g1, g2 StreamOfStates) StreamOfStates {
 	if g1 == nil {
 		return g2
 	}
 	car, cdr := g1()
 	if car != nil { // not a suspension => procedure? == false
 		return func() (*State, StreamOfStates) {
-			return car, mplus(cdr, g2)
+			return car, Mplus(cdr, g2)
 		}
 	}
 	return Suspension(func() StreamOfStates {
-		return mplus(g2, cdr)
+		return Mplus(g2, cdr)
 	})
 }

--- a/micro/fivesandsixes_test.go
+++ b/micro/fivesandsixes_test.go
@@ -10,7 +10,7 @@ import (
 func fives(x *ast.SExpr) GoalFn {
 	return Zzz(DisjointO(
 		EqualO(
-			ast.NewVariable("x"),
+			x,
 			ast.NewInt(5),
 		),
 		func() GoalFn { return fives(x) },
@@ -20,7 +20,7 @@ func fives(x *ast.SExpr) GoalFn {
 func sixes(x *ast.SExpr) GoalFn {
 	return Zzz(DisjointO(
 		EqualO(
-			ast.NewVariable("x"),
+			x,
 			ast.NewInt(6),
 		),
 		func() GoalFn { return sixes(x) },
@@ -36,12 +36,11 @@ func TestFivesAndSixes(t *testing.T) {
 		1,
 		CallFresh(func(q *ast.SExpr) Goal {
 			return EqualO(
-				ast.NewVariable("q"),
-				ast.NewInt(5),
+				q,
+				ast5,
 			)
-		}),
-	)
-	got := Reify("q", states)
+		}))
+	got := MKReify(states)
 	want := []*ast.SExpr{ast5}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %#v but got %#v", got, want)
@@ -55,7 +54,7 @@ func TestFivesAndSixes(t *testing.T) {
 			return func() GoalFn { return fives(x) }
 		}),
 	)
-	got = Reify("x", states)
+	got = MKReify(states)
 	want = []*ast.SExpr{ast5, ast5}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %#v but got %#v", got, want)
@@ -70,7 +69,7 @@ func TestFivesAndSixes(t *testing.T) {
 			)
 		}),
 	)
-	got = Reify("x", states)
+	got = MKReify(states)
 	want = []*ast.SExpr{ast5, ast6, ast5, ast6, ast5, ast6, ast5, ast6, ast5, ast6}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %#v but got %#v", got, want)

--- a/micro/fresh.go
+++ b/micro/fresh.go
@@ -6,8 +6,13 @@ import (
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
 
+// Var creates a new variable as the string vC
+func Var(c int) *ast.SExpr {
+	return ast.NewVariable(fmt.Sprintf("v%d", c))
+}
+
 /*
-CallFresh expects a function that expects a varaible and returns a Goal.
+CallFresh expects a function that expects a variable and returns a Goal.
 
 scheme code:
 
@@ -23,10 +28,10 @@ scheme code:
 		)
 	)
 */
-func CallFresh(f func(v *ast.SExpr) Goal) Goal {
+func CallFresh(f func(*ast.SExpr) Goal) Goal {
 	return func() GoalFn {
 		return func(s *State) StreamOfStates {
-			v := ast.NewVariable(fmt.Sprintf("v%d", s.Counter))
+			v := Var(s.Counter)
 			ss := &State{s.Substitutions, s.Counter + 1}
 			return f(v)()(ss)
 		}

--- a/micro/goal.go
+++ b/micro/goal.go
@@ -67,6 +67,14 @@ func RunGoal(n int, g Goal) []*State {
 	return takeStream(n, ss)
 }
 
+// Run behaves like the default miniKanren run command
+func Run(n int, g func(*ast.SExpr) Goal) []*ast.SExpr {
+	v := Var(0)
+	ss := g(v)()(&State{nil, 1})
+	states := takeStream(n, ss)
+	return MKReify(states)
+}
+
 // SuccessO is a goal that always returns the input state in the resulting stream of states.
 func SuccessO() GoalFn {
 	return func(s *State) StreamOfStates {

--- a/micro/reify.go
+++ b/micro/reify.go
@@ -80,6 +80,13 @@ func ReifyVarFromState(v string) func(s *State) *ast.SExpr {
 }
 
 // Reify reifies the input variable for the given input states.
+// NOTE: this is not the same reify as in the paper, mKreify
 func Reify(v string, ss []*State) []*ast.SExpr {
 	return deriveFmapRs(ReifyVarFromState(v), ss)
+}
+
+// MKReify finds reifications for the first introduced var
+// NOTE: the way we've set this up now, vX is a reserved keyword
+func MKReify(ss []*State) []*ast.SExpr {
+	return deriveFmapRs(ReifyVarFromState("v0"), ss)
 }

--- a/mini/conde.go
+++ b/mini/conde.go
@@ -1,4 +1,8 @@
-package micro
+package mini
+
+import (
+	"github.com/awalterschulze/gominikanren/micro"
+)
 
 /*
 ConjPlus is a macro that extends conjunction to arbitrary arguments
@@ -8,19 +12,19 @@ ConjPlus is a macro that extends conjunction to arbitrary arguments
     ((_ g) (Zzz g))
     ((_ g0 g . . . ) (conj (Zzz g0) (conj+ g . . . )))))
 */
-func ConjPlus(gs ...Goal) Goal {
+func ConjPlus(gs ...micro.Goal) micro.Goal {
 	if len(gs) == 0 {
-		return SuccessO
+		return micro.SuccessO
 	}
 	if len(gs) == 1 {
-		return Zzz(gs[0])
+		return micro.Zzz(gs[0])
 	}
-	g1 := Zzz(gs[0])
+	g1 := micro.Zzz(gs[0])
 	g2 := ConjPlus(gs[1:]...)
-	return func() GoalFn {
-		return func(s *State) StreamOfStates {
+	return func() micro.GoalFn {
+		return func(s *micro.State) micro.StreamOfStates {
 			g1s := g1()(s)
-			return Bind(g1s, g2)
+			return micro.Bind(g1s, g2)
 		}
 	}
 }
@@ -33,20 +37,20 @@ DisjPlus is a macro that extends disjunction to arbitrary arguments
     ((_ g) (Zzz g))
     ((_ g0 g . . . ) (disj (Zzz g0) (disj+ g . . . )))))
 */
-func DisjPlus(gs ...Goal) Goal {
+func DisjPlus(gs ...micro.Goal) micro.Goal {
 	if len(gs) == 0 {
-		return FailureO
+		return micro.FailureO
 	}
 	if len(gs) == 1 {
-		return Zzz(gs[0])
+		return micro.Zzz(gs[0])
 	}
-	g1 := Zzz(gs[0])
+	g1 := micro.Zzz(gs[0])
 	g2 := DisjPlus(gs[1:]...)
-	return func() GoalFn {
-		return func(s *State) StreamOfStates {
+	return func() micro.GoalFn {
+		return func(s *micro.State) micro.StreamOfStates {
 			g1s := g1()(s)
 			g2s := g2()(s)
-			return mplus(g1s, g2s)
+			return micro.Mplus(g1s, g2s)
 		}
 	}
 }
@@ -58,8 +62,8 @@ Conde is a disjunction of conjunctions
 (syntax- rules ()
     ((_ (g0 g . . . ) . . . ) (disj+ (conj+ g0 g . . . ) . . . ))))
 */
-func Conde(gs ...[]Goal) Goal {
-	conj := make([]Goal, len(gs))
+func Conde(gs ...[]micro.Goal) micro.Goal {
+	conj := make([]micro.Goal, len(gs))
 	for i, v := range gs {
 		conj[i] = ConjPlus(v...)
 	}

--- a/mini/recursive_test.go
+++ b/mini/recursive_test.go
@@ -1,9 +1,9 @@
-package micro
+package mini
 
 import (
 	"testing"
 
-	"github.com/awalterschulze/gominikanren/sexpr/ast"
+	"github.com/awalterschulze/gominikanren/micro"
 )
 
 /*
@@ -15,27 +15,25 @@ import (
     ((very-recursiveo))
     ((nevero))))
 */
-func veryRecursiveO() GoalFn {
+func veryRecursiveO() micro.GoalFn {
 	return Conde(
-		[]Goal{NeverO},
-		[]Goal{veryRecursiveO},
-		[]Goal{AlwaysO},
-		[]Goal{veryRecursiveO},
-		[]Goal{NeverO},
+		[]micro.Goal{micro.NeverO},
+		[]micro.Goal{veryRecursiveO},
+		[]micro.Goal{micro.AlwaysO},
+		[]micro.Goal{veryRecursiveO},
+		[]micro.Goal{micro.NeverO},
 	)()
 }
 
 func TestRecursive(t *testing.T) {
-	ss := RunGoal(
+	ss := micro.RunGoal(
 		5,
-		CallFresh(func(q *ast.SExpr) Goal {
-			return Zzz(veryRecursiveO)
-		}),
+		micro.Zzz(veryRecursiveO),
 	)
 	if len(ss) != 5 {
 		t.Fatalf("expected %d, but got %d results", 5, len(ss))
 	}
-	sexprs := Reify("q", ss)
+	sexprs := micro.Reify("q", ss)
 	for _, sexpr := range sexprs {
 		if sexpr.String() != "_0" {
 			t.Fatalf("expected %s, but got %s instead", "_0", sexpr.String())


### PR DESCRIPTION
We can now properly define relations and call them from other code, without variable scope getting mixed up.
The key insight was that mK-reify from the paper was missing: it simply reifies state with the first introduced var.
I kept the old reify intact, since it is perfectly valid (just confused me when it wasn't doing what mK-reify does)

Other things in this commit: 
* introduced the Run() function which behaves like miniKanren's run
* moved conde and friends to /mini