### PR TITLE
concurrent disj plus without zzz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ lint:
 
 .PHONY: bench
 bench:
-	go test ./... -count=1 -bench=. -benchtime=10s
+	go test ./... -bench=. -benchtime=10s

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,13 @@ errcheck:
 	go get github.com/kisielk/errcheck
 	errcheck ./...
 
+.PHONY: lint
 lint:
 	go get golang.org/x/lint/golint
 	golint -set_exit_status ./micro
 	golint -set_exit_status ./mini
 	golint -set_exit_status ./sexpr
+
+.PHONY: bench
+bench:
+	go test ./... -count=1 -bench=. -benchtime=10s

--- a/concurrent/concurrency.go
+++ b/concurrent/concurrency.go
@@ -31,11 +31,11 @@ func DisjPlus(gs ...micro.Goal) micro.Goal {
 					ch <- answer{i: index, s: ss}
 				}(i, g)
 			}
-            for _ = range gs {
+			for range gs {
 				ans := <-ch
 				list[ans.i] = ans.s
 			}
-            stream := list[len(gs)-1]
+			stream := list[len(gs)-1]
 			for i := len(gs) - 2; i >= 0; i-- {
 				stream = micro.Mplus(list[i], stream)
 			}

--- a/concurrent/concurrency.go
+++ b/concurrent/concurrency.go
@@ -1,4 +1,4 @@
-package mini
+package concurrent
 
 import (
 	"github.com/awalterschulze/gominikanren/micro"
@@ -14,7 +14,7 @@ ConcurrentDisjPlus is a macro that extends disjunction to arbitrary arguments
 It resolves its arguments in parallel and merges them at the end
 Notably, unlike DisjPlus, it does _not_ wrap its goals in Zzz
 */
-func ConcurrentDisjPlus(gs ...micro.Goal) micro.Goal {
+func DisjPlus(gs ...micro.Goal) micro.Goal {
 	if len(gs) == 0 {
 		return micro.FailureO
 	}
@@ -31,15 +31,12 @@ func ConcurrentDisjPlus(gs ...micro.Goal) micro.Goal {
 					ch <- answer{i: index, s: ss}
 				}(i, g)
 			}
-			for i := 0; i < len(gs); i++ {
+            for _ = range gs {
 				ans := <-ch
 				list[ans.i] = ans.s
 			}
-			stream := micro.Mplus(list[len(gs)-2], list[len(gs)-1])
-			if len(gs) == 2 {
-				return stream
-			}
-			for i := len(gs) - 3; i >= 0; i-- {
+            stream := list[len(gs)-1]
+			for i := len(gs) - 2; i >= 0; i-- {
 				stream = micro.Mplus(list[i], stream)
 			}
 			return stream

--- a/concurrent/concurrency_test.go
+++ b/concurrent/concurrency_test.go
@@ -1,0 +1,20 @@
+package concurrent
+
+import (
+    "reflect"
+    "testing"
+
+	"github.com/awalterschulze/gominikanren/mini"
+)
+
+func TestConcurrentDisjPlus(t *testing.T) {
+    disjunction = mini.DisjPlus
+    goal := einstein()
+    sexprs := runEinstein(goal)
+    disjunction = DisjPlus
+    goal = einstein()
+    concsexprs := runEinstein(goal)
+    if !reflect.DeepEqual(sexprs, concsexprs) {
+        t.Fatalf("expected equal outcomes but got %#v %#v", sexprs, concsexprs)
+    }
+}

--- a/concurrent/concurrency_test.go
+++ b/concurrent/concurrency_test.go
@@ -4,7 +4,9 @@ import (
     "reflect"
     "testing"
 
+	"github.com/awalterschulze/gominikanren/micro"
 	"github.com/awalterschulze/gominikanren/mini"
+	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
 
 func TestConcurrentDisjPlus(t *testing.T) {
@@ -17,4 +19,65 @@ func TestConcurrentDisjPlus(t *testing.T) {
     if !reflect.DeepEqual(sexprs, concsexprs) {
         t.Fatalf("expected equal outcomes but got %#v %#v", sexprs, concsexprs)
     }
+}
+
+func memberOfLargeList(n int) func(*ast.SExpr) micro.Goal {
+    ints := make([]*ast.SExpr, n)
+    for i := 0; i < n; i++ {
+        ints[i] = ast.NewInt(int64(i))
+    }
+    membero := memberOUnrolled(ast.NewList(ints...))
+    return func(q *ast.SExpr) micro.Goal {
+        return membero(q)
+    }
+}
+
+func TestHeavilyConcurrentDisj(t *testing.T) {
+    disjunction = DisjPlus
+    n := 10000
+    membero := memberOfLargeList(n)
+    sexprs := micro.Run(-1, membero)
+    if len(sexprs) != n {
+        t.Fatalf("expected %d results but got %d", n, len(sexprs))
+    }
+}
+
+func BenchmarkMembero10000(b *testing.B) {
+	disjunction = disjPlus
+    membero := memberOfLargeList(10000)
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = micro.Run(-1, membero)
+	}
+	result = r
+}
+
+func BenchmarkConcMembero10000(b *testing.B) {
+	disjunction = DisjPlus
+    membero := memberOfLargeList(10000)
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = micro.Run(-1, membero)
+	}
+	result = r
+}
+
+func BenchmarkMembero50000(b *testing.B) {
+	disjunction = disjPlus
+    membero := memberOfLargeList(50000)
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = micro.Run(-1, membero)
+	}
+	result = r
+}
+
+func BenchmarkConcMembero50000(b *testing.B) {
+	disjunction = DisjPlus
+    membero := memberOfLargeList(50000)
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = micro.Run(-1, membero)
+	}
+	result = r
 }

--- a/concurrent/concurrency_test.go
+++ b/concurrent/concurrency_test.go
@@ -68,6 +68,7 @@ func TestHeavilyConcurrentDisj(t *testing.T) {
 func benchMembero(b *testing.B, listsize int) {
 	membero := memberOfLargeList(listsize)
 	var r []*ast.SExpr
+    b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r = micro.Run(-1, membero)
 	}
@@ -133,6 +134,7 @@ func equalLargeList(n int) func(*ast.SExpr) micro.Goal {
 func benchMapo(b *testing.B, listsize int) {
 	membero := equalLargeList(listsize)
 	var r []*ast.SExpr
+    b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r = micro.Run(-1, membero)
 	}
@@ -186,6 +188,7 @@ func equalFailHeadLargeList(n int) func(*ast.SExpr) micro.Goal {
 func benchMapoFailHead(b *testing.B, listsize int) {
 	membero := equalFailHeadLargeList(listsize)
 	var r []*ast.SExpr
+    b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r = micro.Run(-1, membero)
 	}
@@ -222,6 +225,7 @@ func equalFailTailLargeList(n int) func(*ast.SExpr) micro.Goal {
 func benchMapoFailTail(b *testing.B, listsize int) {
 	membero := equalFailTailLargeList(listsize)
 	var r []*ast.SExpr
+    b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r = micro.Run(-1, membero)
 	}

--- a/concurrent/concurrency_test.go
+++ b/concurrent/concurrency_test.go
@@ -1,70 +1,137 @@
 package concurrent
 
 import (
-    "reflect"
-    "testing"
+	"reflect"
+	"testing"
 
 	"github.com/awalterschulze/gominikanren/micro"
 	"github.com/awalterschulze/gominikanren/mini"
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
 
+var (
+	result      []*ast.SExpr
+	disjunction func(...micro.Goal) micro.Goal
+	conjunction func(...micro.Goal) micro.Goal
+)
+
 func TestConcurrentDisjPlus(t *testing.T) {
-    disjunction = mini.DisjPlus
-    goal := einstein()
-    sexprs := runEinstein(goal)
-    disjunction = DisjPlus
-    goal = einstein()
-    concsexprs := runEinstein(goal)
-    if !reflect.DeepEqual(sexprs, concsexprs) {
-        t.Fatalf("expected equal outcomes but got %#v %#v", sexprs, concsexprs)
-    }
+	disjunction = mini.DisjPlus
+	goal := einstein()
+	sexprs := runEinstein(goal)
+	disjunction = DisjPlus
+	goal = einstein()
+	concsexprs := runEinstein(goal)
+	if !reflect.DeepEqual(sexprs, concsexprs) {
+		t.Fatalf("expected equal outcomes but got %#v %#v", sexprs, concsexprs)
+	}
+}
+
+func TestConcurrentConjPlus(t *testing.T) {
+	conjunction = mini.ConjPlus
+	goal := equalLargeList(10)
+	sexprs := micro.Run(-1, goal)
+	conjunction = ConjPlus
+	goal = equalLargeList(10)
+	concsexprs := micro.Run(-1, goal)
+	if !reflect.DeepEqual(sexprs, concsexprs) {
+		t.Fatalf("expected equal outcomes but got %#v %#v", sexprs, concsexprs)
+	}
+}
+
+func largeList(n int) *ast.SExpr {
+	ints := make([]*ast.SExpr, n)
+	for i := 0; i < n; i++ {
+		ints[i] = ast.NewInt(int64(i))
+	}
+	return ast.NewList(ints...)
 }
 
 func memberOfLargeList(n int) func(*ast.SExpr) micro.Goal {
-    ints := make([]*ast.SExpr, n)
-    for i := 0; i < n; i++ {
-        ints[i] = ast.NewInt(int64(i))
-    }
-    membero := memberOUnrolled(ast.NewList(ints...))
-    return func(q *ast.SExpr) micro.Goal {
-        return membero(q)
-    }
+	membero := memberOUnrolled(largeList(n))
+	return func(q *ast.SExpr) micro.Goal {
+		return membero(q)
+	}
 }
 
 func TestHeavilyConcurrentDisj(t *testing.T) {
-    disjunction = DisjPlus
-    n := 10000
-    membero := memberOfLargeList(n)
-    sexprs := micro.Run(-1, membero)
-    if len(sexprs) != n {
-        t.Fatalf("expected %d results but got %d", n, len(sexprs))
-    }
+	disjunction = DisjPlus
+	n := 10000
+	membero := memberOfLargeList(n)
+	sexprs := micro.Run(-1, membero)
+	if len(sexprs) != n {
+		t.Fatalf("expected %d results but got %d", n, len(sexprs))
+	}
+}
+
+// before calling bench, remember to set disjunction
+func benchMembero(b *testing.B, listsize int) {
+	membero := memberOfLargeList(listsize)
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = micro.Run(-1, membero)
+	}
+	result = r
 }
 
 func BenchmarkMembero10000(b *testing.B) {
 	disjunction = disjPlus
-    membero := memberOfLargeList(10000)
-	var r []*ast.SExpr
-	for n := 0; n < b.N; n++ {
-		r = micro.Run(-1, membero)
-	}
-	result = r
+	benchMembero(b, 10000)
 }
 
 func BenchmarkConcMembero10000(b *testing.B) {
 	disjunction = DisjPlus
-    membero := memberOfLargeList(10000)
-	var r []*ast.SExpr
-	for n := 0; n < b.N; n++ {
-		r = micro.Run(-1, membero)
-	}
-	result = r
+	benchMembero(b, 10000)
 }
 
 func BenchmarkMembero50000(b *testing.B) {
 	disjunction = disjPlus
-    membero := memberOfLargeList(50000)
+	benchMembero(b, 50000)
+}
+
+func BenchmarkConcMembero50000(b *testing.B) {
+	disjunction = DisjPlus
+	benchMembero(b, 50000)
+}
+
+func mapODoubleUnrolled(f func(*ast.SExpr, *ast.SExpr) micro.Goal, list *ast.SExpr) func(*ast.SExpr) micro.Goal {
+	goals := []func(*ast.SExpr) micro.Goal{}
+	for {
+		if list == nil {
+			break
+		}
+		car, cdr := list.Car(), list.Cdr()
+		goals = append(goals, func(x *ast.SExpr) micro.Goal {
+			return f(x, car)
+		})
+		list = cdr
+	}
+	n := len(goals)
+	return func(x *ast.SExpr) micro.Goal {
+		gs := make([]micro.Goal, n+1)
+		vars := make([]*ast.SExpr, n)
+		var cons *ast.SExpr = nil
+		for i := 0; i < n; i++ {
+			v := ast.NewVariable("")
+			vars[i] = v
+			gs[n-i] = goals[n-i-1](v)
+			cons = ast.Cons(v, cons)
+		}
+		gs[0] = micro.EqualO(x, cons)
+		return conjunction(gs...)
+	}
+}
+
+func equalLargeList(n int) func(*ast.SExpr) micro.Goal {
+	mapo := mapODoubleUnrolled(micro.EqualO, largeList(n))
+	return func(q *ast.SExpr) micro.Goal {
+		return mapo(q)
+	}
+}
+
+// before calling bench, remember to set conjunction
+func benchMapo(b *testing.B, listsize int) {
+	membero := equalLargeList(listsize)
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
 		r = micro.Run(-1, membero)
@@ -72,12 +139,101 @@ func BenchmarkMembero50000(b *testing.B) {
 	result = r
 }
 
-func BenchmarkConcMembero50000(b *testing.B) {
-	disjunction = DisjPlus
-    membero := memberOfLargeList(50000)
+func conjPlus(gs ...micro.Goal) micro.Goal {
+	if len(gs) == 0 {
+		return micro.SuccessO
+	}
+	if len(gs) == 1 {
+		return gs[0]
+	}
+	g1 := gs[0]
+	g2 := conjPlus(gs[1:]...)
+	return func() micro.GoalFn {
+		return func(s *micro.State) micro.StreamOfStates {
+			g1s := g1()(s)
+			return micro.Bind(g1s, g2)
+		}
+	}
+}
+
+func BenchmarkMapo10000(b *testing.B) {
+	conjunction = conjPlus
+	benchMapo(b, 10000)
+}
+
+func BenchmarkConcMapo10000(b *testing.B) {
+	conjunction = ConjPlus
+	benchMapo(b, 10000)
+}
+
+func largeListHeadFail(n int) *ast.SExpr {
+	ints := make([]*ast.SExpr, n)
+	for i := 0; i < n-1; i++ {
+		ints[i] = ast.NewInt(int64(i))
+	}
+	ints[0] = ast.NewInt(1)
+	return ast.NewList(ints...)
+}
+
+func equalFailHeadLargeList(n int) func(*ast.SExpr) micro.Goal {
+	list := largeList(n)
+	mapo := mapODoubleUnrolled(micro.EqualO, list)
+	list2 := largeListHeadFail(n)
+	return func(*ast.SExpr) micro.Goal { return mapo(list2) }
+}
+
+// before calling bench, remember to set conjunction
+func benchMapoFailHead(b *testing.B, listsize int) {
+	membero := equalFailHeadLargeList(listsize)
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
 		r = micro.Run(-1, membero)
 	}
 	result = r
+}
+
+func BenchmarkMapoFailHead10000(b *testing.B) {
+	conjunction = conjPlus
+	benchMapoFailHead(b, 10000)
+}
+
+func BenchmarkConcMapoFailHead10000(b *testing.B) {
+	conjunction = ConjPlus
+	benchMapoFailHead(b, 10000)
+}
+
+func largeListTailFail(n int) *ast.SExpr {
+	ints := make([]*ast.SExpr, n)
+	for i := 0; i < n-1; i++ {
+		ints[i] = ast.NewInt(int64(i))
+	}
+	ints[n-1] = ast.NewInt(0)
+	return ast.NewList(ints...)
+}
+
+func equalFailTailLargeList(n int) func(*ast.SExpr) micro.Goal {
+	list := largeList(n)
+	mapo := mapODoubleUnrolled(micro.EqualO, list)
+	list2 := largeListTailFail(n)
+	return func(*ast.SExpr) micro.Goal { return mapo(list2) }
+}
+
+// before calling bench, remember to set conjunction
+func benchMapoFailTail(b *testing.B, listsize int) {
+	membero := equalFailTailLargeList(listsize)
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = micro.Run(-1, membero)
+	}
+	result = r
+}
+
+func BenchmarkMapoFailTail10000(b *testing.B) {
+	conjunction = conjPlus
+	benchMapoFailTail(b, 10000)
+}
+
+func BenchmarkConcMapoFailTail10000(b *testing.B) {
+	conjunction = ConjPlus
+	benchMapoFailTail(b, 10000)
 }

--- a/concurrent/einstein_test.go
+++ b/concurrent/einstein_test.go
@@ -9,14 +9,9 @@ import (
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
 
-var (
-	result      []*ast.SExpr
-	disjunction func(...micro.Goal) micro.Goal
-)
-
 func BenchmarkEinsteinSeqZzz(b *testing.B) {
 	disjunction = mini.DisjPlus
-    goal := einstein()
+	goal := einstein()
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
 		r = runEinstein(goal)
@@ -26,7 +21,7 @@ func BenchmarkEinsteinSeqZzz(b *testing.B) {
 
 func BenchmarkEinsteinSeq(b *testing.B) {
 	disjunction = disjPlus
-    goal := einstein()
+	goal := einstein()
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
 		r = runEinstein(goal)
@@ -36,7 +31,7 @@ func BenchmarkEinsteinSeq(b *testing.B) {
 
 func BenchmarkEinsteinConcZzz(b *testing.B) {
 	disjunction = concDisjPlusZzz
-    goal := einstein()
+	goal := einstein()
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
 		r = runEinstein(goal)
@@ -46,7 +41,7 @@ func BenchmarkEinsteinConcZzz(b *testing.B) {
 
 func BenchmarkEinsteinConc(b *testing.B) {
 	disjunction = DisjPlus
-    goal := einstein()
+	goal := einstein()
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
 		r = runEinstein(goal)

--- a/concurrent/einstein_test.go
+++ b/concurrent/einstein_test.go
@@ -1,0 +1,250 @@
+package concurrent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/awalterschulze/gominikanren/micro"
+	"github.com/awalterschulze/gominikanren/mini"
+	"github.com/awalterschulze/gominikanren/sexpr/ast"
+)
+
+var (
+	result      []*ast.SExpr
+	disjunction func(...micro.Goal) micro.Goal
+)
+
+func BenchmarkEinsteinSeqZzz(b *testing.B) {
+	disjunction = mini.DisjPlus
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = einstein()
+	}
+	result = r
+}
+
+func BenchmarkEinsteinSeq(b *testing.B) {
+	disjunction = disjPlus
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = einstein()
+	}
+	result = r
+}
+
+func BenchmarkEinsteinConcZzz(b *testing.B) {
+	disjunction = concDisjPlusZzz
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = einstein()
+	}
+	result = r
+}
+
+func BenchmarkEinsteinConc(b *testing.B) {
+	disjunction = DisjPlus
+	var r []*ast.SExpr
+	for n := 0; n < b.N; n++ {
+		r = einstein()
+	}
+	result = r
+}
+
+func disjPlus(gs ...micro.Goal) micro.Goal {
+	if len(gs) == 0 {
+		return micro.FailureO
+	}
+	if len(gs) == 1 {
+		return gs[0]
+	}
+	g1 := gs[0]
+	g2 := disjPlus(gs[1:]...)
+	return func() micro.GoalFn {
+		return func(s *micro.State) micro.StreamOfStates {
+			g1s := g1()(s)
+			g2s := g2()(s)
+			return micro.Mplus(g1s, g2s)
+		}
+	}
+}
+
+func concDisjPlusZzz(gs ...micro.Goal) micro.Goal {
+	if len(gs) == 0 {
+		return micro.FailureO
+	}
+	if len(gs) == 1 {
+		return micro.Zzz(gs[0])
+	}
+	return func() micro.GoalFn {
+		return func(s *micro.State) micro.StreamOfStates {
+			list := make([]micro.StreamOfStates, len(gs))
+			ch := make(chan answer)
+			for i, g := range gs {
+				go func(index int, goal micro.Goal) {
+					ss := micro.Zzz(goal)()(s)
+					ch <- answer{i: index, s: ss}
+				}(i, g)
+			}
+			for range gs {
+				ans := <-ch
+				list[ans.i] = ans.s
+			}
+			stream := list[len(gs)-1]
+			for i := len(gs) - 2; i >= 0; i-- {
+				stream = micro.Mplus(list[i], stream)
+			}
+			return stream
+		}
+	}
+}
+
+func memberOUnrolled(y *ast.SExpr) func(*ast.SExpr) micro.Goal {
+	goals := []func(*ast.SExpr) micro.Goal{}
+	for {
+		if y == nil {
+			break
+		}
+		car, cdr := y.Car(), y.Cdr()
+		goals = append(goals, func(x *ast.SExpr) micro.Goal {
+			return micro.EqualO(x, car)
+		})
+		y = cdr
+	}
+	n := len(goals)
+	return func(x *ast.SExpr) micro.Goal {
+		gs := make([]micro.Goal, n)
+		for i, g := range goals {
+			gs[i] = g(x)
+		}
+		return disjunction(gs...)
+
+	}
+}
+
+func einstein() []*ast.SExpr {
+	one := ast.NewSymbol("one")
+	two := ast.NewSymbol("two")
+	three := ast.NewSymbol("three")
+	four := ast.NewSymbol("four")
+	five := ast.NewSymbol("five")
+
+	rightOf := func(x, y *ast.SExpr) micro.Goal {
+		return disjunction(
+			micro.ConjunctionO(
+				micro.EqualO(y, one),
+				micro.EqualO(x, two),
+			),
+			micro.ConjunctionO(
+				micro.EqualO(y, two),
+				micro.EqualO(x, three),
+			),
+			micro.ConjunctionO(
+				micro.EqualO(y, three),
+				micro.EqualO(x, four),
+			),
+			micro.ConjunctionO(
+				micro.EqualO(y, four),
+				micro.EqualO(x, five),
+			),
+		)
+	}
+
+	leftOf := func(x, y *ast.SExpr) micro.Goal {
+		return rightOf(y, x)
+	}
+
+	nextTo := func(x, y *ast.SExpr) micro.Goal {
+		return micro.DisjointO(
+			leftOf(x, y),
+			rightOf(x, y),
+		)
+	}
+
+	anon := func() *ast.SExpr {
+		return ast.NewVariable(time.Now().String())
+	}
+
+	streetDef := ast.NewList(
+		ast.NewList(one, anon(), anon(), anon(), anon(), anon()),
+		ast.NewList(two, anon(), anon(), anon(), anon(), anon()),
+		ast.NewList(three, anon(), anon(), anon(), anon(), anon()),
+		ast.NewList(four, anon(), anon(), anon(), anon(), anon()),
+		ast.NewList(five, anon(), anon(), anon(), anon(), anon()),
+	)
+
+	streetEq := func(q *ast.SExpr) micro.Goal {
+		return micro.EqualO(
+			q,
+			streetDef,
+		)
+	}
+
+	mUnrolled := memberOUnrolled(streetDef)
+
+	solution := func(street, fishowner, a, b, c, d, e, f, g, h, i, j *ast.SExpr) micro.Goal {
+		return mini.ConjPlus(
+			streetEq(street),
+			mUnrolled(ast.NewList(anon(), ast.NewSymbol("brit"), ast.NewSymbol("red"), anon(), anon(), anon())),
+			mUnrolled(ast.NewList(anon(), ast.NewSymbol("swede"), anon(), ast.NewSymbol("dog"), anon(), anon())),
+			mUnrolled(ast.NewList(anon(), ast.NewSymbol("dane"), anon(), anon(), ast.NewSymbol("tea"), anon())),
+			mUnrolled(ast.NewList(a, anon(), ast.NewSymbol("green"), anon(), anon(), anon())),
+			mUnrolled(ast.NewList(b, anon(), ast.NewSymbol("white"), anon(), anon(), anon())),
+			leftOf(a, b),
+			mUnrolled(ast.NewList(anon(), anon(), ast.NewSymbol("green"), anon(), ast.NewSymbol("coffee"), anon())),
+			mUnrolled(ast.NewList(anon(), anon(), anon(), ast.NewSymbol("birds"), anon(), ast.NewSymbol("pall-mall"))),
+			mUnrolled(ast.NewList(anon(), anon(), ast.NewSymbol("yellow"), anon(), anon(), ast.NewSymbol("dunhill"))),
+			mUnrolled(ast.NewList(three, anon(), anon(), anon(), ast.NewSymbol("milk"), anon())),
+			mUnrolled(ast.NewList(one, ast.NewSymbol("norwegian"), anon(), anon(), anon(), anon())),
+			mUnrolled(ast.NewList(c, anon(), anon(), anon(), anon(), ast.NewSymbol("blend"))),
+			mUnrolled(ast.NewList(d, anon(), anon(), ast.NewSymbol("cats"), anon(), anon())),
+			nextTo(c, d),
+			mUnrolled(ast.NewList(e, anon(), anon(), ast.NewSymbol("horse"), anon(), anon())),
+			mUnrolled(ast.NewList(f, anon(), anon(), anon(), anon(), ast.NewSymbol("dunhill"))),
+			nextTo(e, f),
+			mUnrolled(ast.NewList(anon(), anon(), anon(), anon(), ast.NewSymbol("beer"), ast.NewSymbol("bluemaster"))),
+			mUnrolled(ast.NewList(anon(), ast.NewSymbol("german"), anon(), anon(), anon(), ast.NewSymbol("prince"))),
+			mUnrolled(ast.NewList(g, ast.NewSymbol("norwegian"), anon(), anon(), anon(), anon())),
+			mUnrolled(ast.NewList(h, anon(), ast.NewSymbol("blue"), anon(), anon(), anon())),
+			nextTo(g, h),
+			mUnrolled(ast.NewList(i, anon(), anon(), anon(), anon(), ast.NewSymbol("blend"))),
+			mUnrolled(ast.NewList(j, anon(), anon(), anon(), ast.NewSymbol("water"), anon())),
+			nextTo(i, j),
+			mUnrolled(ast.NewList(anon(), fishowner, anon(), ast.NewSymbol("fish"), anon(), anon())),
+		)
+	}
+
+	sexprs := micro.Run(-1, func(q *ast.SExpr) micro.Goal {
+		return micro.CallFresh(func(street *ast.SExpr) micro.Goal {
+			return micro.CallFresh(func(fishowner *ast.SExpr) micro.Goal {
+				return micro.ConjunctionO(
+					micro.EqualO(
+						q,
+						ast.Cons(street, ast.Cons(fishowner, nil)),
+					),
+					micro.CallFresh(func(a *ast.SExpr) micro.Goal {
+						return micro.CallFresh(func(b *ast.SExpr) micro.Goal {
+							return micro.CallFresh(func(c *ast.SExpr) micro.Goal {
+								return micro.CallFresh(func(d *ast.SExpr) micro.Goal {
+									return micro.CallFresh(func(e *ast.SExpr) micro.Goal {
+										return micro.CallFresh(func(f *ast.SExpr) micro.Goal {
+											return micro.CallFresh(func(g *ast.SExpr) micro.Goal {
+												return micro.CallFresh(func(h *ast.SExpr) micro.Goal {
+													return micro.CallFresh(func(i *ast.SExpr) micro.Goal {
+														return micro.CallFresh(func(j *ast.SExpr) micro.Goal {
+															return solution(street, fishowner, a, b, c, d, e, f, g, h, i, j)
+														})
+													})
+												})
+											})
+										})
+									})
+								})
+							})
+						})
+					}),
+				)
+			})
+		})
+	})
+	return sexprs
+}

--- a/concurrent/einstein_test.go
+++ b/concurrent/einstein_test.go
@@ -13,6 +13,7 @@ func BenchmarkEinsteinSeqZzz(b *testing.B) {
 	disjunction = mini.DisjPlus
 	goal := einstein()
 	var r []*ast.SExpr
+    b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r = runEinstein(goal)
 	}
@@ -23,6 +24,7 @@ func BenchmarkEinsteinSeq(b *testing.B) {
 	disjunction = disjPlus
 	goal := einstein()
 	var r []*ast.SExpr
+    b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r = runEinstein(goal)
 	}
@@ -33,6 +35,7 @@ func BenchmarkEinsteinConcZzz(b *testing.B) {
 	disjunction = concDisjPlusZzz
 	goal := einstein()
 	var r []*ast.SExpr
+    b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r = runEinstein(goal)
 	}
@@ -43,6 +46,7 @@ func BenchmarkEinsteinConc(b *testing.B) {
 	disjunction = DisjPlus
 	goal := einstein()
 	var r []*ast.SExpr
+    b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r = runEinstein(goal)
 	}

--- a/concurrent/einstein_test.go
+++ b/concurrent/einstein_test.go
@@ -16,36 +16,40 @@ var (
 
 func BenchmarkEinsteinSeqZzz(b *testing.B) {
 	disjunction = mini.DisjPlus
+    goal := einstein()
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
-		r = einstein()
+		r = runEinstein(goal)
 	}
 	result = r
 }
 
 func BenchmarkEinsteinSeq(b *testing.B) {
 	disjunction = disjPlus
+    goal := einstein()
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
-		r = einstein()
+		r = runEinstein(goal)
 	}
 	result = r
 }
 
 func BenchmarkEinsteinConcZzz(b *testing.B) {
 	disjunction = concDisjPlusZzz
+    goal := einstein()
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
-		r = einstein()
+		r = runEinstein(goal)
 	}
 	result = r
 }
 
 func BenchmarkEinsteinConc(b *testing.B) {
 	disjunction = DisjPlus
+    goal := einstein()
 	var r []*ast.SExpr
 	for n := 0; n < b.N; n++ {
-		r = einstein()
+		r = runEinstein(goal)
 	}
 	result = r
 }
@@ -121,7 +125,7 @@ func memberOUnrolled(y *ast.SExpr) func(*ast.SExpr) micro.Goal {
 	}
 }
 
-func einstein() []*ast.SExpr {
+func einstein() func(*ast.SExpr, *ast.SExpr) micro.Goal {
 	one := ast.NewSymbol("one")
 	two := ast.NewSymbol("two")
 	three := ast.NewSymbol("three")
@@ -213,7 +217,33 @@ func einstein() []*ast.SExpr {
 		)
 	}
 
-	sexprs := micro.Run(-1, func(q *ast.SExpr) micro.Goal {
+	return func(street, fishowner *ast.SExpr) micro.Goal {
+		return micro.CallFresh(func(a *ast.SExpr) micro.Goal {
+			return micro.CallFresh(func(b *ast.SExpr) micro.Goal {
+				return micro.CallFresh(func(c *ast.SExpr) micro.Goal {
+					return micro.CallFresh(func(d *ast.SExpr) micro.Goal {
+						return micro.CallFresh(func(e *ast.SExpr) micro.Goal {
+							return micro.CallFresh(func(f *ast.SExpr) micro.Goal {
+								return micro.CallFresh(func(g *ast.SExpr) micro.Goal {
+									return micro.CallFresh(func(h *ast.SExpr) micro.Goal {
+										return micro.CallFresh(func(i *ast.SExpr) micro.Goal {
+											return micro.CallFresh(func(j *ast.SExpr) micro.Goal {
+												return solution(street, fishowner, a, b, c, d, e, f, g, h, i, j)
+											})
+										})
+									})
+								})
+							})
+						})
+					})
+				})
+			})
+		})
+	}
+}
+
+func runEinstein(goal func(*ast.SExpr, *ast.SExpr) micro.Goal) []*ast.SExpr {
+	return micro.Run(-1, func(q *ast.SExpr) micro.Goal {
 		return micro.CallFresh(func(street *ast.SExpr) micro.Goal {
 			return micro.CallFresh(func(fishowner *ast.SExpr) micro.Goal {
 				return micro.ConjunctionO(
@@ -221,30 +251,9 @@ func einstein() []*ast.SExpr {
 						q,
 						ast.Cons(street, ast.Cons(fishowner, nil)),
 					),
-					micro.CallFresh(func(a *ast.SExpr) micro.Goal {
-						return micro.CallFresh(func(b *ast.SExpr) micro.Goal {
-							return micro.CallFresh(func(c *ast.SExpr) micro.Goal {
-								return micro.CallFresh(func(d *ast.SExpr) micro.Goal {
-									return micro.CallFresh(func(e *ast.SExpr) micro.Goal {
-										return micro.CallFresh(func(f *ast.SExpr) micro.Goal {
-											return micro.CallFresh(func(g *ast.SExpr) micro.Goal {
-												return micro.CallFresh(func(h *ast.SExpr) micro.Goal {
-													return micro.CallFresh(func(i *ast.SExpr) micro.Goal {
-														return micro.CallFresh(func(j *ast.SExpr) micro.Goal {
-															return solution(street, fishowner, a, b, c, d, e, f, g, h, i, j)
-														})
-													})
-												})
-											})
-										})
-									})
-								})
-							})
-						})
-					}),
+					goal(street, fishowner),
 				)
 			})
 		})
 	})
-	return sexprs
 }

--- a/mini/concurrency.go
+++ b/mini/concurrency.go
@@ -5,8 +5,8 @@ import (
 )
 
 type answer struct {
-    i int
-    s micro.StreamOfStates
+	i int
+	s micro.StreamOfStates
 }
 
 /*
@@ -23,26 +23,26 @@ func ConcurrentDisjPlus(gs ...micro.Goal) micro.Goal {
 	}
 	return func() micro.GoalFn {
 		return func(s *micro.State) micro.StreamOfStates {
-            list := make([]micro.StreamOfStates, len(gs))
-            ch := make(chan answer)
-            for i, g := range gs {
-                go func(index int, goal micro.Goal) {
-                    ss := goal()(s)
-                    ch <- answer{i:index, s:ss}
-                }(i, g)
-            }
-            for i:=0; i<len(gs); i++ {
-                ans := <-ch
-                list[ans.i] = ans.s
-            }
-            stream := micro.Mplus(list[len(gs)-2], list[len(gs)-1])
-            if len(gs) == 2 {
-                return stream
-            }
-            for i:=len(gs)-3;i>=0;i-- {
-                stream = micro.Mplus(list[i], stream)
-            }
-            return stream
+			list := make([]micro.StreamOfStates, len(gs))
+			ch := make(chan answer)
+			for i, g := range gs {
+				go func(index int, goal micro.Goal) {
+					ss := goal()(s)
+					ch <- answer{i: index, s: ss}
+				}(i, g)
+			}
+			for i := 0; i < len(gs); i++ {
+				ans := <-ch
+				list[ans.i] = ans.s
+			}
+			stream := micro.Mplus(list[len(gs)-2], list[len(gs)-1])
+			if len(gs) == 2 {
+				return stream
+			}
+			for i := len(gs) - 3; i >= 0; i-- {
+				stream = micro.Mplus(list[i], stream)
+			}
+			return stream
 		}
 	}
 }

--- a/mini/concurrency.go
+++ b/mini/concurrency.go
@@ -1,0 +1,48 @@
+package mini
+
+import (
+	"github.com/awalterschulze/gominikanren/micro"
+)
+
+type answer struct {
+    i int
+    s micro.StreamOfStates
+}
+
+/*
+ConcurrentDisjPlus is a macro that extends disjunction to arbitrary arguments
+It resolves its arguments in parallel and merges them at the end
+Notably, unlike DisjPlus, it does _not_ wrap its goals in Zzz
+*/
+func ConcurrentDisjPlus(gs ...micro.Goal) micro.Goal {
+	if len(gs) == 0 {
+		return micro.FailureO
+	}
+	if len(gs) == 1 {
+		return gs[0]
+	}
+	return func() micro.GoalFn {
+		return func(s *micro.State) micro.StreamOfStates {
+            list := make([]micro.StreamOfStates, len(gs))
+            ch := make(chan answer)
+            for i, g := range gs {
+                go func(index int, goal micro.Goal) {
+                    ss := goal()(s)
+                    ch <- answer{i:index, s:ss}
+                }(i, g)
+            }
+            for i:=0; i<len(gs); i++ {
+                ans := <-ch
+                list[ans.i] = ans.s
+            }
+            stream := micro.Mplus(list[len(gs)-2], list[len(gs)-1])
+            if len(gs) == 2 {
+                return stream
+            }
+            for i:=len(gs)-3;i>=0;i-- {
+                stream = micro.Mplus(list[i], stream)
+            }
+            return stream
+		}
+	}
+}

--- a/mini/unroll_test.go
+++ b/mini/unroll_test.go
@@ -52,4 +52,22 @@ func TestMapO(t *testing.T) {
 	if !reflect.DeepEqual(sexprs[0], list) {
 		t.Fatalf("expected output matches input list, but got %#v", sexprs[0])
 	}
+	sexprs = micro.Run(-1, func(q *ast.SExpr) micro.Goal {
+		return MapOUnrolled(list)(micro.EqualO, q)
+	})
+	if len(sexprs) != 1 {
+		t.Fatalf("expected len %d, but got len %d instead", 1, len(sexprs))
+	}
+	if !reflect.DeepEqual(sexprs[0], list) {
+		t.Fatalf("expected output matches input list, but got %#v", sexprs[0])
+	}
+	sexprs = micro.Run(-1, func(q *ast.SExpr) micro.Goal {
+		return MapODoubleUnrolled(micro.EqualO, list)(q)
+	})
+	if len(sexprs) != 1 {
+		t.Fatalf("expected len %d, but got len %d instead", 1, len(sexprs))
+	}
+	if !reflect.DeepEqual(sexprs[0], list) {
+		t.Fatalf("expected output matches input list, but got %#v", sexprs[0])
+	}
 }


### PR DESCRIPTION
Showing that concurrent disjunction can improve performance.
Usecase is again the Einstein puzzle (see other PR).
Benchmarks were run for four different cases, cartesian product of

- disjunction with or without concurrency
- wrapping each goal in a suspend, using Zzz macro

Results are as follows:
```
- Disj with Zzz: ~1.55s
- Disj without Zzz: ~0.67s
- Concurrent disj with Zzz: ~1.73s
- Concurrent disj without Zzz: ~0.58s
```
Mainly shows that Zzz implementation is slow.
Using Zzz by default (as in the 2013 ukanren paper) makes concurrent disjunction even slower in this particular case.
But for the same problem, not wrapping goals in Zzz performs faster using concurrent disjunction.