### PR TITLE
Using uint64 in substitution map

### DIFF
--- a/micro/derived.gen.go
+++ b/micro/derived.gen.go
@@ -7,18 +7,18 @@ import (
 	"sort"
 )
 
-// deriveTupleO returns a function, which returns the input values.
+// deriveTupleE returns a function, which returns the input values.
 // Since tuples are not first class citizens in Go, this is a way to fake it, because functions that return tuples are first class citizens.
-func deriveTupleO(v0 string, v1 string, v2 Substitutions, v3 bool) func() (string, string, Substitutions, bool) {
-	return func() (string, string, Substitutions, bool) {
+func deriveTupleE(v0 *ast.SExpr, v1 *ast.SExpr, v2 Substitutions, v3 Substitutions) func() (*ast.SExpr, *ast.SExpr, Substitutions, Substitutions) {
+	return func() (*ast.SExpr, *ast.SExpr, Substitutions, Substitutions) {
 		return v0, v1, v2, v3
 	}
 }
 
-// deriveTupleE returns a function, which returns the input values.
+// deriveTuple3SVars returns a function, which returns the input values.
 // Since tuples are not first class citizens in Go, this is a way to fake it, because functions that return tuples are first class citizens.
-func deriveTupleE(v0 string, v1 string, v2 Substitutions, v3 Substitutions) func() (string, string, Substitutions, Substitutions) {
-	return func() (string, string, Substitutions, Substitutions) {
+func deriveTuple3SVars(v0 *ast.SExpr, v1 *ast.SExpr, v2 Substitutions, v3 bool) func() (*ast.SExpr, *ast.SExpr, Substitutions, bool) {
+	return func() (*ast.SExpr, *ast.SExpr, Substitutions, bool) {
 		return v0, v1, v2, v3
 	}
 }
@@ -31,23 +31,23 @@ func deriveTuple3(v0 string, v1 string, v2 string) func() (string, string, strin
 	}
 }
 
-// deriveTuple3S returns a function, which returns the input values.
+// deriveTuple3SVar returns a function, which returns the input values.
 // Since tuples are not first class citizens in Go, this is a way to fake it, because functions that return tuples are first class citizens.
-func deriveTuple3S(v0 string, v1 Substitutions, v2 string) func() (string, Substitutions, string) {
-	return func() (string, Substitutions, string) {
+func deriveTuple3SVar(v0 *ast.SExpr, v1 Substitutions, v2 string) func() (*ast.SExpr, Substitutions, string) {
+	return func() (*ast.SExpr, Substitutions, string) {
 		return v0, v1, v2
 	}
 }
 
 // deriveSorted sorts the slice inplace and also returns it.
-func deriveSorted(list []string) []string {
-	sort.Strings(list)
+func deriveSorted(list []uint64) []uint64 {
+	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
 	return list
 }
 
 // deriveKeys returns the keys of the input map as a slice.
-func deriveKeys(m map[string]*ast.SExpr) []string {
-	keys := make([]string, 0, len(m))
+func deriveKeys(m map[uint64]*ast.SExpr) []uint64 {
+	keys := make([]uint64, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)
 	}

--- a/micro/derived.gen.go
+++ b/micro/derived.gen.go
@@ -7,18 +7,18 @@ import (
 	"sort"
 )
 
-// deriveTupleE returns a function, which returns the input values.
-// Since tuples are not first class citizens in Go, this is a way to fake it, because functions that return tuples are first class citizens.
-func deriveTupleE(v0 *ast.SExpr, v1 *ast.SExpr, v2 Substitutions, v3 Substitutions) func() (*ast.SExpr, *ast.SExpr, Substitutions, Substitutions) {
-	return func() (*ast.SExpr, *ast.SExpr, Substitutions, Substitutions) {
-		return v0, v1, v2, v3
-	}
-}
-
 // deriveTuple3SVars returns a function, which returns the input values.
 // Since tuples are not first class citizens in Go, this is a way to fake it, because functions that return tuples are first class citizens.
 func deriveTuple3SVars(v0 *ast.SExpr, v1 *ast.SExpr, v2 Substitutions, v3 bool) func() (*ast.SExpr, *ast.SExpr, Substitutions, bool) {
 	return func() (*ast.SExpr, *ast.SExpr, Substitutions, bool) {
+		return v0, v1, v2, v3
+	}
+}
+
+// deriveTupleE returns a function, which returns the input values.
+// Since tuples are not first class citizens in Go, this is a way to fake it, because functions that return tuples are first class citizens.
+func deriveTupleE(v0 *ast.SExpr, v1 *ast.SExpr, v2 Substitutions, v3 Substitutions) func() (*ast.SExpr, *ast.SExpr, Substitutions, Substitutions) {
+	return func() (*ast.SExpr, *ast.SExpr, Substitutions, Substitutions) {
 		return v0, v1, v2, v3
 	}
 }

--- a/micro/exts.go
+++ b/micro/exts.go
@@ -30,11 +30,11 @@ func exts(x *ast.Variable, v *ast.SExpr, s Substitutions) (Substitutions, bool) 
 	if occurs(x, v, s) {
 		return nil, false
 	}
-    m := make(map[string]*ast.SExpr, len(s))
-    for key, value := range s {
-        m[key] = value
-    }
-	m[x.Name] = v
+	m := make(map[uint64]*ast.SExpr, len(s))
+	for key, value := range s {
+		m[key] = value
+	}
+	m[x.Index] = v
 	return m, true
 }
 

--- a/micro/exts_test.go
+++ b/micro/exts_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
 
+// helper func used in all tests that use Substitution of vars
+func indexOf(x *ast.SExpr) uint64 {
+	return x.Atom.Var.Index
+}
+
 func TestOccurs(t *testing.T) {
 	x := ast.NewVar("x", 0)
 	y := ast.NewVar("y", 1)
@@ -13,7 +18,7 @@ func TestOccurs(t *testing.T) {
 		deriveTuple3SVars(x, x, Substitutions(nil), true),
 		deriveTuple3SVars(x, y, nil, false),
 		deriveTuple3SVars(x, ast.NewList(y), Substitutions{
-			1: x,
+			indexOf(y): x,
 		}, true),
 	}
 	for _, test := range tests {
@@ -33,23 +38,23 @@ func TestExts(t *testing.T) {
 	z := ast.NewVar("z", 2)
 	tests := []func() (*ast.SExpr, *ast.SExpr, Substitutions, Substitutions){
 		deriveTupleE(x, ast.NewSymbol("a"), Substitutions(nil), Substitutions{
-			0: ast.NewSymbol("a"),
+			indexOf(x): ast.NewSymbol("a"),
 		}),
 		deriveTupleE(x, ast.NewList(x), Substitutions(nil), Substitutions(nil)),
 		deriveTupleE(x, ast.NewList(y),
 			Substitutions{
-				1: x,
+				indexOf(y): x,
 			},
 			Substitutions(nil)),
 		deriveTupleE(x, ast.NewSymbol("e"),
 			Substitutions{
-				2: x,
-				1: z,
+				indexOf(z): x,
+				indexOf(y): z,
 			},
 			Substitutions{
-				0: ast.NewSymbol("e"),
-				2: x,
-				1: z,
+				indexOf(x): ast.NewSymbol("e"),
+				indexOf(z): x,
+				indexOf(y): z,
 			},
 		),
 	}

--- a/micro/fresh.go
+++ b/micro/fresh.go
@@ -8,7 +8,7 @@ import (
 
 // Var creates a new variable as the string vC
 func Var(c int) *ast.SExpr {
-	return ast.NewVariable(fmt.Sprintf("v%d", c))
+	return ast.NewVar(fmt.Sprintf("v%d", c), uint64(c))
 }
 
 /*

--- a/micro/fresh.go
+++ b/micro/fresh.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Var creates a new variable as the string vC
-func Var(c int) *ast.SExpr {
-	return ast.NewVar(fmt.Sprintf("v%d", c), uint64(c))
+func Var(c uint64) *ast.SExpr {
+	return ast.NewVar(fmt.Sprintf("v%d", c), c)
 }
 
 /*

--- a/micro/goal.go
+++ b/micro/goal.go
@@ -2,7 +2,6 @@ package micro
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
@@ -10,15 +9,15 @@ import (
 // State is a product of a list of substitutions and a variable counter.
 type State struct {
 	Substitutions
-	Counter int
+	Counter uint64
 }
 
 // String returns a string representation of State.
 func (s *State) String() string {
 	if s.Substitutions == nil {
-		return "(" + "()" + " . " + strconv.Itoa(s.Counter) + ")"
+		return fmt.Sprintf("(() . %d)", s.Counter)
 	}
-	return "(" + s.Substitutions.String() + " . " + strconv.Itoa(s.Counter) + ")"
+	return fmt.Sprintf("(%s . %d)", s.Substitutions.String(), s.Counter)
 }
 
 // EmptyState returns an empty state.
@@ -34,7 +33,7 @@ func (s Substitutions) String() string {
 	ss := map[uint64]*ast.SExpr(s)
 	for i, k := range deriveSorted(deriveKeys(ss)) {
 		v := s[k]
-		vv := ast.NewVar(fmt.Sprintf("v%d", k), k)
+		vv := Var(k)
 		vvv := ast.Cons(vv, v)
 		sexprs[len(s)-1-i] = vvv
 	}

--- a/micro/goal.go
+++ b/micro/goal.go
@@ -1,6 +1,7 @@
 package micro
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
@@ -26,24 +27,20 @@ func EmptyState() *State {
 }
 
 // Substitutions is a list of substitutions represented by a sexprs pair.
-type Substitutions map[string]*ast.SExpr
+type Substitutions map[uint64]*ast.SExpr
 
 func (s Substitutions) String() string {
 	sexprs := make([]*ast.SExpr, len(s))
-	ss := map[string]*ast.SExpr(s)
+	ss := map[uint64]*ast.SExpr(s)
 	for i, k := range deriveSorted(deriveKeys(ss)) {
 		v := s[k]
-		sexprs[len(s)-1-i] = ast.Cons(&ast.SExpr{Atom: &ast.Atom{Var: &ast.Variable{Name: k}}}, v)
+		vv := ast.NewVar(fmt.Sprintf("v%d", k), k)
+		vvv := ast.Cons(vv, v)
+		sexprs[len(s)-1-i] = vvv
 	}
 	l := ast.NewList(sexprs...).String()
 	return l[1 : len(l)-1]
 }
-
-/*
-func (s Substitution) String() string {
-	return ast.Cons(&ast.SExpr{Atom: &ast.Atom{Var: &ast.Variable{Name: s.Var}}}, s.Value).String()
-}
-*/
 
 // GoalFn is a function that takes a state and returns a stream of states.
 type GoalFn func(*State) StreamOfStates

--- a/micro/goal_test.go
+++ b/micro/goal_test.go
@@ -69,7 +69,7 @@ func TestDisjointO1(t *testing.T) {
 	s, sok := d()
 	got := s.String()
 	// reifying y; we assigned it a random uint64 and lost track of it
-	got = strings.Replace(got, fmt.Sprintf("v%d", x.Atom.Var.Index), "x", -1)
+	got = strings.Replace(got, fmt.Sprintf("v%d", indexOf(x)), "x", -1)
 	want := "((,x . olive) . 0)"
 	if got != want {
 		t.Fatalf("got %s != want %s", got, want)
@@ -98,7 +98,7 @@ func TestDisjointO2(t *testing.T) {
 	s, sok = sok()
 	got := s.String()
 	// reifying y; we assigned it a random uint64 and lost track of it
-	got = strings.Replace(got, fmt.Sprintf("v%d", x.Atom.Var.Index), "x", -1)
+	got = strings.Replace(got, fmt.Sprintf("v%d", indexOf(x)), "x", -1)
 	want := "((,x . olive) . 0)"
 	if got != want {
 		t.Fatalf("got %s != want %s", got, want)
@@ -190,7 +190,7 @@ func TestRunGoalConj2OneResults(t *testing.T) {
 	}
 	got := ss[0].String()
 	// reifying y; we assigned it a random uint64 and lost track of it
-	got = strings.Replace(got, fmt.Sprintf("v%d", x.Atom.Var.Index), "x", -1)
+	got = strings.Replace(got, fmt.Sprintf("v%d", indexOf(x)), "x", -1)
 	want := "((,x . olive) . 0)"
 	if got != want {
 		t.Fatalf("got %s != want %s", got, want)

--- a/micro/goal_test.go
+++ b/micro/goal_test.go
@@ -1,6 +1,7 @@
 package micro
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -57,15 +58,18 @@ func TestNeverO(t *testing.T) {
 }
 
 func TestDisjointO1(t *testing.T) {
+	x := ast.NewVariable("x")
 	d := DisjointO(
 		EqualO(
 			ast.NewSymbol("olive"),
-			ast.NewVariable("x"),
+			x,
 		),
 		NeverO,
 	)()(EmptyState())
 	s, sok := d()
 	got := s.String()
+	// reifying y; we assigned it a random uint64 and lost track of it
+	got = strings.Replace(got, fmt.Sprintf("v%d", x.Atom.Var.Index), "x", -1)
 	want := "((,x . olive) . 0)"
 	if got != want {
 		t.Fatalf("got %s != want %s", got, want)
@@ -76,11 +80,12 @@ func TestDisjointO1(t *testing.T) {
 }
 
 func TestDisjointO2(t *testing.T) {
+	x := ast.NewVariable("x")
 	d := DisjointO(
 		NeverO,
 		EqualO(
 			ast.NewSymbol("olive"),
-			ast.NewVariable("x"),
+			x,
 		),
 	)()(EmptyState())
 	s, sok := d()
@@ -92,6 +97,8 @@ func TestDisjointO2(t *testing.T) {
 	}
 	s, sok = sok()
 	got := s.String()
+	// reifying y; we assigned it a random uint64 and lost track of it
+	got = strings.Replace(got, fmt.Sprintf("v%d", x.Atom.Var.Index), "x", -1)
 	want := "((,x . olive) . 0)"
 	if got != want {
 		t.Fatalf("got %s != want %s", got, want)
@@ -150,13 +157,14 @@ func TestRunGoalDisj2(t *testing.T) {
 }
 
 func TestRunGoalConj2NoResults(t *testing.T) {
+	x := ast.NewVariable("x")
 	e1 := EqualO(
 		ast.NewSymbol("olive"),
-		ast.NewVariable("x"),
+		x,
 	)
 	e2 := EqualO(
 		ast.NewSymbol("oil"),
-		ast.NewVariable("x"),
+		x,
 	)
 	g := ConjunctionO(e1, e2)
 	ss := RunGoal(5, g)
@@ -166,13 +174,14 @@ func TestRunGoalConj2NoResults(t *testing.T) {
 }
 
 func TestRunGoalConj2OneResults(t *testing.T) {
+	x := ast.NewVariable("x")
 	e1 := EqualO(
 		ast.NewSymbol("olive"),
-		ast.NewVariable("x"),
+		x,
 	)
 	e2 := EqualO(
 		ast.NewSymbol("olive"),
-		ast.NewVariable("x"),
+		x,
 	)
 	g := ConjunctionO(e1, e2)
 	ss := RunGoal(5, g)
@@ -180,6 +189,8 @@ func TestRunGoalConj2OneResults(t *testing.T) {
 		t.Fatalf("expected 1, got %d: %v", len(ss), ss)
 	}
 	got := ss[0].String()
+	// reifying y; we assigned it a random uint64 and lost track of it
+	got = strings.Replace(got, fmt.Sprintf("v%d", x.Atom.Var.Index), "x", -1)
 	want := "((,x . olive) . 0)"
 	if got != want {
 		t.Fatalf("got %s != want %s", got, want)

--- a/micro/reify.go
+++ b/micro/reify.go
@@ -54,11 +54,11 @@ func reifys(v *ast.SExpr, s Substitutions) Substitutions {
 	}
 	if vv.IsVariable() {
 		n := reifyName(len(s))
-        m := make(map[string]*ast.SExpr, len(s))
-        for key, value := range s {
-            m[key] = value
-        }
-		m[vv.Atom.Var.Name] = n
+		m := make(map[uint64]*ast.SExpr, len(s))
+		for key, value := range s {
+			m[key] = value
+		}
+		m[vv.Atom.Var.Index] = n
 		return m
 	}
 	if vv.IsPair() {
@@ -79,6 +79,15 @@ func ReifyVarFromState(v string) func(s *State) *ast.SExpr {
 	}
 }
 
+// ReifyIntVarFromState is a curried function that reifies the input variable for the given input state.
+func ReifyIntVarFromState(v uint64) func(s *State) *ast.SExpr {
+	return func(s *State) *ast.SExpr {
+		vv := walkStar(&ast.SExpr{Atom: &ast.Atom{Var: &ast.Variable{Index: v}}}, s.Substitutions)
+		r := reifyS(vv)
+		return walkStar(vv, r)
+	}
+}
+
 // Reify reifies the input variable for the given input states.
 // NOTE: this is not the same reify as in the paper, mKreify
 func Reify(v string, ss []*State) []*ast.SExpr {
@@ -88,5 +97,5 @@ func Reify(v string, ss []*State) []*ast.SExpr {
 // MKReify finds reifications for the first introduced var
 // NOTE: the way we've set this up now, vX is a reserved keyword
 func MKReify(ss []*State) []*ast.SExpr {
-	return deriveFmapRs(ReifyVarFromState("v0"), ss)
+	return deriveFmapRs(ReifyIntVarFromState(0), ss)
 }

--- a/micro/reify_test.go
+++ b/micro/reify_test.go
@@ -34,17 +34,17 @@ func TestReify(t *testing.T) {
 	y := ast.NewVar("y", 4)
 	z := ast.NewVar("z", 5)
 	a1 := ast.NewList(x, u, w, y, z, ast.NewList(ast.NewList(ast.NewSymbol("ice")), z))
-	a2 := ast.NewList(y, ast.NewSymbol("corn"))
+	a2 := ast.Cons(y, ast.NewSymbol("corn"))
 	a3 := ast.NewList(w, v, u)
 	e := ast.NewList(a1, a2, a3)
 	ss := Substitutions{
-		3: e.Car().Cdr(),
-		4: e.Cdr().Car().Cdr(),
-		2: e.Cdr().Cdr().Car().Cdr(),
+		indexOf(x): e.Car().Cdr(),
+		indexOf(y): e.Cdr().Car().Cdr(),
+		indexOf(w): e.Cdr().Cdr().Car().Cdr(),
 	}
-	gote := ReifyIntVarFromState(3)(&State{Substitutions: ss})
+	gote := ReifyIntVarFromState(indexOf(x))(&State{Substitutions: ss})
 	got := gote.String()
-	want := "(_0 (_1 _0) (corn) _2 ((ice) _2))"
+	want := "(_0 (_1 _0) corn _2 ((ice) _2))"
 	if got != want {
 		t.Fatalf("got %s != want %s", got, want)
 	}
@@ -64,7 +64,7 @@ func TestNoReify(t *testing.T) {
 	states := RunGoal(5, g)
 	ss := make([]*ast.SExpr, len(states))
 	strs := make([]string, len(states))
-	r := ReifyIntVarFromState(x.Atom.Var.Index)
+	r := ReifyIntVarFromState(indexOf(x))
 	for i, s := range states {
 		ss[i] = r(s)
 		strs[i] = ss[i].String()

--- a/micro/reify_test.go
+++ b/micro/reify_test.go
@@ -13,7 +13,7 @@ scheme code:
 	(let
 		(
 			(a1 `(,x . (,u ,w ,y ,z ((ice) ,z))))
-			(a2 `(,y . (corn)))
+			(a2 `(,y . corn))
 			(a3 `(,w . (,v ,u)))
 		)
 		(let

--- a/micro/walk.go
+++ b/micro/walk.go
@@ -40,7 +40,7 @@ func assv(v *ast.Variable, ss Substitutions) (*ast.SExpr, bool) {
 	if ss == nil {
 		return nil, false
 	}
-	value, ok := ss[v.Name]
+	value, ok := ss[v.Index]
 	if !ok {
 		return nil, false
 	}

--- a/micro/walk_test.go
+++ b/micro/walk_test.go
@@ -6,35 +6,38 @@ import (
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
 
-// u v w x y z
-// 0 1 2 3 4 5
 func TestWalk(t *testing.T) {
+	v := ast.NewVar("v", 1)
+	w := ast.NewVar("w", 2)
+	x := ast.NewVar("x", 3)
+	y := ast.NewVar("y", 4)
+	z := ast.NewVar("z", 5)
 	zaxwyz := Substitutions{
-		5: ast.NewSymbol("a"),
-		3: ast.NewVar("w", 2),
-		4: ast.NewVar("z", 5),
+		indexOf(z): ast.NewSymbol("a"),
+		indexOf(x): w,
+		indexOf(y): z,
 	}
 	xyvxwx := Substitutions{
-		3: ast.NewVar("y", 4),
-		1: ast.NewVar("x", 3),
-		2: ast.NewVar("x", 3),
+		indexOf(x): y,
+		indexOf(v): x,
+		indexOf(w): x,
 	}
 	tests := []func() (*ast.SExpr, Substitutions, string){
-		deriveTuple3SVar(ast.NewVar("z", 5), zaxwyz, "a"),
-		deriveTuple3SVar(ast.NewVar("y", 4), zaxwyz, "a"),
-		deriveTuple3SVar(ast.NewVar("x", 3), zaxwyz, ",w"),
-		deriveTuple3SVar(ast.NewVar("x", 3), xyvxwx, ",y"),
-		deriveTuple3SVar(ast.NewVar("v", 1), xyvxwx, ",y"),
-		deriveTuple3SVar(ast.NewVar("w", 2), xyvxwx, ",y"),
-		deriveTuple3SVar(ast.NewVar("w", 2), Substitutions{
-			3: ast.NewSymbol("b"),
-			5: ast.NewVar("y", 4),
-			2: ast.NewList(ast.NewVar("x", 3), ast.NewSymbol("e"), ast.NewVar("z", 5)),
+		deriveTuple3SVar(z, zaxwyz, "a"),
+		deriveTuple3SVar(y, zaxwyz, "a"),
+		deriveTuple3SVar(x, zaxwyz, ",w"),
+		deriveTuple3SVar(x, xyvxwx, ",y"),
+		deriveTuple3SVar(v, xyvxwx, ",y"),
+		deriveTuple3SVar(w, xyvxwx, ",y"),
+		deriveTuple3SVar(w, Substitutions{
+			indexOf(x): ast.NewSymbol("b"),
+			indexOf(z): y,
+			indexOf(w): ast.NewList(x, ast.NewSymbol("e"), z),
 		}, "(,x e ,z)"),
-		deriveTuple3SVar(ast.NewVar("y", 4), Substitutions{
-			3: ast.NewSymbol("e"),
-			5: ast.NewVar("x", 3),
-			4: ast.NewVar("z", 5),
+		deriveTuple3SVar(y, Substitutions{
+			indexOf(x): ast.NewSymbol("e"),
+			indexOf(z): x,
+			indexOf(y): z,
 		}, "e"),
 	}
 	for _, test := range tests {
@@ -49,32 +52,37 @@ func TestWalk(t *testing.T) {
 }
 
 func TestWalkStar(t *testing.T) {
+	v := ast.NewVar("v", 1)
+	w := ast.NewVar("w", 2)
+	x := ast.NewVar("x", 3)
+	y := ast.NewVar("y", 4)
+	z := ast.NewVar("z", 5)
 	zaxwyz := Substitutions{
-		5: ast.NewSymbol("a"),
-		3: ast.NewVar("w", 2),
-		4: ast.NewVar("z", 5),
+		indexOf(z): ast.NewSymbol("a"),
+		indexOf(x): w,
+		indexOf(y): z,
 	}
 	xyvxwx := Substitutions{
-		3: ast.NewVar("y", 4),
-		1: ast.NewVar("x", 3),
-		2: ast.NewVar("x", 3),
+		indexOf(x): y,
+		indexOf(v): x,
+		indexOf(w): x,
 	}
 	tests := []func() (*ast.SExpr, Substitutions, string){
-		deriveTuple3SVar(ast.NewVar("z", 5), zaxwyz, "a"),
-		deriveTuple3SVar(ast.NewVar("y", 4), zaxwyz, "a"),
-		deriveTuple3SVar(ast.NewVar("x", 3), zaxwyz, ",w"),
-		deriveTuple3SVar(ast.NewVar("x", 3), xyvxwx, ",y"),
-		deriveTuple3SVar(ast.NewVar("v", 1), xyvxwx, ",y"),
-		deriveTuple3SVar(ast.NewVar("w", 2), xyvxwx, ",y"),
-		deriveTuple3SVar(ast.NewVar("w", 2), Substitutions{
-			3: ast.NewSymbol("b"),
-			5: ast.NewVar("y", 4),
-			2: ast.NewList(ast.NewVar("x", 3), ast.NewSymbol("e"), ast.NewVar("z", 5)),
+		deriveTuple3SVar(z, zaxwyz, "a"),
+		deriveTuple3SVar(y, zaxwyz, "a"),
+		deriveTuple3SVar(x, zaxwyz, ",w"),
+		deriveTuple3SVar(x, xyvxwx, ",y"),
+		deriveTuple3SVar(v, xyvxwx, ",y"),
+		deriveTuple3SVar(w, xyvxwx, ",y"),
+		deriveTuple3SVar(w, Substitutions{
+			indexOf(x): ast.NewSymbol("b"),
+			indexOf(z): y,
+			indexOf(w): ast.NewList(x, ast.NewSymbol("e"), z),
 		}, "(b e ,y)"),
-		deriveTuple3SVar(ast.NewVar("y", 4), Substitutions{
-			3: ast.NewSymbol("e"),
-			5: ast.NewVar("x", 3),
-			4: ast.NewVar("z", 5),
+		deriveTuple3SVar(y, Substitutions{
+			indexOf(x): ast.NewSymbol("e"),
+			indexOf(z): x,
+			indexOf(y): z,
 		}, "e"),
 	}
 	for _, test := range tests {

--- a/micro/walk_test.go
+++ b/micro/walk_test.go
@@ -6,39 +6,40 @@ import (
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
 
+// u v w x y z
+// 0 1 2 3 4 5
 func TestWalk(t *testing.T) {
 	zaxwyz := Substitutions{
-		"z": ast.NewSymbol("a"),
-		"x": ast.NewVariable("w"),
-		"y": ast.NewVariable("z"),
+		5: ast.NewSymbol("a"),
+		3: ast.NewVar("w", 2),
+		4: ast.NewVar("z", 5),
 	}
 	xyvxwx := Substitutions{
-		"x": ast.NewVariable("y"),
-		"v": ast.NewVariable("x"),
-		"w": ast.NewVariable("x"),
+		3: ast.NewVar("y", 4),
+		1: ast.NewVar("x", 3),
+		2: ast.NewVar("x", 3),
 	}
-	tests := []func() (string, Substitutions, string){
-		deriveTuple3S("z", zaxwyz, "a"),
-		deriveTuple3S("y", zaxwyz, "a"),
-		deriveTuple3S("x", zaxwyz, ",w"),
-		deriveTuple3S("x", xyvxwx, ",y"),
-		deriveTuple3S("v", xyvxwx, ",y"),
-		deriveTuple3S("w", xyvxwx, ",y"),
-		deriveTuple3S("w", Substitutions{
-			"x": ast.NewSymbol("b"),
-			"z": ast.NewVariable("y"),
-			"w": ast.NewList(ast.NewVariable("x"), ast.NewSymbol("e"), ast.NewVariable("z")),
+	tests := []func() (*ast.SExpr, Substitutions, string){
+		deriveTuple3SVar(ast.NewVar("z", 5), zaxwyz, "a"),
+		deriveTuple3SVar(ast.NewVar("y", 4), zaxwyz, "a"),
+		deriveTuple3SVar(ast.NewVar("x", 3), zaxwyz, ",w"),
+		deriveTuple3SVar(ast.NewVar("x", 3), xyvxwx, ",y"),
+		deriveTuple3SVar(ast.NewVar("v", 1), xyvxwx, ",y"),
+		deriveTuple3SVar(ast.NewVar("w", 2), xyvxwx, ",y"),
+		deriveTuple3SVar(ast.NewVar("w", 2), Substitutions{
+			3: ast.NewSymbol("b"),
+			5: ast.NewVar("y", 4),
+			2: ast.NewList(ast.NewVar("x", 3), ast.NewSymbol("e"), ast.NewVar("z", 5)),
 		}, "(,x e ,z)"),
-		deriveTuple3S("y", Substitutions{
-			"x": ast.NewSymbol("e"),
-			"z": ast.NewVariable("x"),
-			"y": ast.NewVariable("z"),
+		deriveTuple3SVar(ast.NewVar("y", 4), Substitutions{
+			3: ast.NewSymbol("e"),
+			5: ast.NewVar("x", 3),
+			4: ast.NewVar("z", 5),
 		}, "e"),
 	}
 	for _, test := range tests {
-		q, subs, want := test()
-		t.Run("(walk "+q+" "+subs.String()+")", func(t *testing.T) {
-			v := ast.NewVariable(q)
+		v, subs, want := test()
+		t.Run("(walk "+v.Atom.Var.Name+" "+subs.String()+")", func(t *testing.T) {
 			got := walk(v.Atom.Var, subs).String()
 			if want != got {
 				t.Fatalf("got %s want %s", got, want)
@@ -49,37 +50,36 @@ func TestWalk(t *testing.T) {
 
 func TestWalkStar(t *testing.T) {
 	zaxwyz := Substitutions{
-		"z": ast.NewSymbol("a"),
-		"x": ast.NewVariable("w"),
-		"y": ast.NewVariable("z"),
+		5: ast.NewSymbol("a"),
+		3: ast.NewVar("w", 2),
+		4: ast.NewVar("z", 5),
 	}
 	xyvxwx := Substitutions{
-		"x": ast.NewVariable("y"),
-		"v": ast.NewVariable("x"),
-		"w": ast.NewVariable("x"),
+		3: ast.NewVar("y", 4),
+		1: ast.NewVar("x", 3),
+		2: ast.NewVar("x", 3),
 	}
-	tests := []func() (string, Substitutions, string){
-		deriveTuple3S("z", zaxwyz, "a"),
-		deriveTuple3S("y", zaxwyz, "a"),
-		deriveTuple3S("x", zaxwyz, ",w"),
-		deriveTuple3S("x", xyvxwx, ",y"),
-		deriveTuple3S("v", xyvxwx, ",y"),
-		deriveTuple3S("w", xyvxwx, ",y"),
-		deriveTuple3S("w", Substitutions{
-			"x": ast.NewSymbol("b"),
-			"z": ast.NewVariable("y"),
-			"w": ast.NewList(ast.NewVariable("x"), ast.NewSymbol("e"), ast.NewVariable("z")),
+	tests := []func() (*ast.SExpr, Substitutions, string){
+		deriveTuple3SVar(ast.NewVar("z", 5), zaxwyz, "a"),
+		deriveTuple3SVar(ast.NewVar("y", 4), zaxwyz, "a"),
+		deriveTuple3SVar(ast.NewVar("x", 3), zaxwyz, ",w"),
+		deriveTuple3SVar(ast.NewVar("x", 3), xyvxwx, ",y"),
+		deriveTuple3SVar(ast.NewVar("v", 1), xyvxwx, ",y"),
+		deriveTuple3SVar(ast.NewVar("w", 2), xyvxwx, ",y"),
+		deriveTuple3SVar(ast.NewVar("w", 2), Substitutions{
+			3: ast.NewSymbol("b"),
+			5: ast.NewVar("y", 4),
+			2: ast.NewList(ast.NewVar("x", 3), ast.NewSymbol("e"), ast.NewVar("z", 5)),
 		}, "(b e ,y)"),
-		deriveTuple3S("y", Substitutions{
-			"x": ast.NewSymbol("e"),
-			"z": ast.NewVariable("x"),
-			"y": ast.NewVariable("z"),
+		deriveTuple3SVar(ast.NewVar("y", 4), Substitutions{
+			3: ast.NewSymbol("e"),
+			5: ast.NewVar("x", 3),
+			4: ast.NewVar("z", 5),
 		}, "e"),
 	}
 	for _, test := range tests {
-		q, subs, want := test()
-		t.Run("(walk "+q+" "+subs.String()+")", func(t *testing.T) {
-			v := ast.NewVariable(q)
+		v, subs, want := test()
+		t.Run("(walk "+v.Atom.Var.Name+" "+subs.String()+")", func(t *testing.T) {
 			got := walkStar(v, subs).String()
 			if want != got {
 				t.Fatalf("got %s want %s", got, want)

--- a/mini/einstein_test.go
+++ b/mini/einstein_test.go
@@ -2,7 +2,6 @@ package mini
 
 import (
 	"testing"
-	"time"
 
 	"github.com/awalterschulze/gominikanren/micro"
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
@@ -75,13 +74,10 @@ func TestEinstein(t *testing.T) {
 	}
 
 	// NOTE: these should be anonymous vars, but we cannot make those atm without using call/fresh
-	// I'm creating vars with unique random names (from unix time) instead, for now
-	// somehow ast.NewVariable can introduce vars with scope: if you change one of the var names in
-	// street to duplicate another, you will see them substituted in variable bindings in state
+	// for the purposes of this test we don't care about their names clashing;
+	// their underlying index value will be unique
 	anon := func() *ast.SExpr {
-		time.Sleep(1000)
-		t := time.Now()
-		return ast.NewVar(t.String(), uint64(t.UnixNano()))
+		return ast.NewVariable("_")
 	}
 
 	streetDef := ast.NewList(

--- a/mini/einstein_test.go
+++ b/mini/einstein_test.go
@@ -79,7 +79,9 @@ func TestEinstein(t *testing.T) {
 	// somehow ast.NewVariable can introduce vars with scope: if you change one of the var names in
 	// street to duplicate another, you will see them substituted in variable bindings in state
 	anon := func() *ast.SExpr {
-		return ast.NewVariable(time.Now().String())
+		time.Sleep(1000)
+		t := time.Now()
+		return ast.NewVar(t.String(), uint64(t.UnixNano()))
 	}
 
 	streetDef := ast.NewList(

--- a/mini/ifthenelse_test.go
+++ b/mini/ifthenelse_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/awalterschulze/gominikanren/sexpr/ast"
 )
 
+// helper func used in all tests that use Substitution of vars
+func indexOf(x *ast.SExpr) uint64 {
+	return x.Atom.Var.Index
+}
+
 func TestIfThenElseSuccess(t *testing.T) {
 	y := ast.NewVariable("y")
 	ifte := IfThenElseO(

--- a/mini/ifthenelse_test.go
+++ b/mini/ifthenelse_test.go
@@ -19,7 +19,7 @@ func TestIfThenElseSuccess(t *testing.T) {
 	ss := ifte(micro.EmptyState())
 	got := ss.String()
 	// reifying y; we assigned it a random uint64 and lost track of it
-	got = strings.Replace(got, fmt.Sprintf("v%d", y.Atom.Var.Index), "y", -1)
+	got = strings.Replace(got, fmt.Sprintf("v%d", indexOf(y)), "y", -1)
 	want := "(((,y . #f) . 0))"
 	if got != want {
 		t.Fatalf("got %v != want %v", got, want)
@@ -36,7 +36,7 @@ func TestIfThenElseFailure(t *testing.T) {
 	ss := ifte(micro.EmptyState())
 	got := ss.String()
 	// reifying y; we assigned it a random uint64 and lost track of it
-	got = strings.Replace(got, fmt.Sprintf("v%d", y.Atom.Var.Index), "y", -1)
+	got = strings.Replace(got, fmt.Sprintf("v%d", indexOf(y)), "y", -1)
 	want := "(((,y . #t) . 0))"
 	if got != want {
 		t.Fatalf("got %v != want %v", got, want)

--- a/mini/ifthenelse_test.go
+++ b/mini/ifthenelse_test.go
@@ -1,6 +1,8 @@
 package mini
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/awalterschulze/gominikanren/micro"
@@ -8,13 +10,16 @@ import (
 )
 
 func TestIfThenElseSuccess(t *testing.T) {
+	y := ast.NewVariable("y")
 	ifte := IfThenElseO(
 		micro.SuccessO,
-		micro.EqualO(ast.NewSymbol("#f"), ast.NewVariable("y")),
-		micro.EqualO(ast.NewSymbol("#t"), ast.NewVariable("y")),
+		micro.EqualO(ast.NewSymbol("#f"), y),
+		micro.EqualO(ast.NewSymbol("#t"), y),
 	)()
 	ss := ifte(micro.EmptyState())
 	got := ss.String()
+	// reifying y; we assigned it a random uint64 and lost track of it
+	got = strings.Replace(got, fmt.Sprintf("v%d", y.Atom.Var.Index), "y", -1)
 	want := "(((,y . #f) . 0))"
 	if got != want {
 		t.Fatalf("got %v != want %v", got, want)
@@ -22,13 +27,16 @@ func TestIfThenElseSuccess(t *testing.T) {
 }
 
 func TestIfThenElseFailure(t *testing.T) {
+	y := ast.NewVariable("y")
 	ifte := IfThenElseO(
 		micro.FailureO,
-		micro.EqualO(ast.NewSymbol("#f"), ast.NewVariable("y")),
-		micro.EqualO(ast.NewSymbol("#t"), ast.NewVariable("y")),
+		micro.EqualO(ast.NewSymbol("#f"), y),
+		micro.EqualO(ast.NewSymbol("#t"), y),
 	)()
 	ss := ifte(micro.EmptyState())
 	got := ss.String()
+	// reifying y; we assigned it a random uint64 and lost track of it
+	got = strings.Replace(got, fmt.Sprintf("v%d", y.Atom.Var.Index), "y", -1)
 	want := "(((,y . #t) . 0))"
 	if got != want {
 		t.Fatalf("got %v != want %v", got, want)
@@ -36,13 +44,20 @@ func TestIfThenElseFailure(t *testing.T) {
 }
 
 func TestIfThenElseXIsTrue(t *testing.T) {
+	// assigning var index by hand since we want x < y
+	// otherwise test can fail because of int order in substitution map
+	x := ast.NewVar("x", 10001)
+	y := ast.NewVar("y", 10002)
 	ifte := IfThenElseO(
-		micro.EqualO(ast.NewSymbol("#t"), ast.NewVariable("x")),
-		micro.EqualO(ast.NewSymbol("#f"), ast.NewVariable("y")),
-		micro.EqualO(ast.NewSymbol("#t"), ast.NewVariable("y")),
+		micro.EqualO(ast.NewSymbol("#t"), x),
+		micro.EqualO(ast.NewSymbol("#f"), y),
+		micro.EqualO(ast.NewSymbol("#t"), y),
 	)()
 	ss := ifte(micro.EmptyState())
 	got := ss.String()
+	// reifying x and y; we assigned them a random uint64 and lost track of it
+	got = strings.Replace(got, "v10001", "x", -1)
+	got = strings.Replace(got, "v10002", "y", -1)
 	want := "(((,y . #f) (,x . #t) . 0))"
 	if got != want {
 		t.Fatalf("got %v != want %v", got, want)
@@ -50,16 +65,23 @@ func TestIfThenElseXIsTrue(t *testing.T) {
 }
 
 func TestIfThenElseDisjoint(t *testing.T) {
+	// assigning var index by hand since we want x < y
+	// otherwise test can fail because of int order in substitution map
+	x := ast.NewVar("x", 10001)
+	y := ast.NewVar("y", 10002)
 	ifte := IfThenElseO(
 		micro.DisjointO(
-			micro.EqualO(ast.NewSymbol("#t"), ast.NewVariable("x")),
-			micro.EqualO(ast.NewSymbol("#f"), ast.NewVariable("x")),
+			micro.EqualO(ast.NewSymbol("#t"), x),
+			micro.EqualO(ast.NewSymbol("#f"), x),
 		),
-		micro.EqualO(ast.NewSymbol("#f"), ast.NewVariable("y")),
-		micro.EqualO(ast.NewSymbol("#t"), ast.NewVariable("y")),
+		micro.EqualO(ast.NewSymbol("#f"), y),
+		micro.EqualO(ast.NewSymbol("#t"), y),
 	)()
 	ss := ifte(micro.EmptyState())
 	got := ss.String()
+	// reifying x and y; we assigned them a random uint64 and lost track of it
+	got = strings.Replace(got, "v10001", "x", -1)
+	got = strings.Replace(got, "v10002", "y", -1)
 	want := "(((,y . #f) (,x . #t) . 0) ((,y . #f) (,x . #f) . 0))"
 	if got != want {
 		t.Fatalf("got %v != want %v", got, want)

--- a/mini/once_test.go
+++ b/mini/once_test.go
@@ -1,6 +1,7 @@
 package mini
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/awalterschulze/gominikanren/micro"
@@ -8,16 +9,23 @@ import (
 )
 
 func TestOnce(t *testing.T) {
+	// assigning var index by hand since we want x < y
+	// otherwise test can fail because of int order in substitution map
+	x := ast.NewVar("x", 10001)
+	y := ast.NewVar("y", 10002)
 	ifte := IfThenElseO(
 		OnceO(micro.DisjointO(
-			micro.EqualO(ast.NewSymbol("#t"), ast.NewVariable("x")),
-			micro.EqualO(ast.NewSymbol("#f"), ast.NewVariable("x")),
+			micro.EqualO(ast.NewSymbol("#t"), x),
+			micro.EqualO(ast.NewSymbol("#f"), x),
 		)),
-		micro.EqualO(ast.NewSymbol("#f"), ast.NewVariable("y")),
-		micro.EqualO(ast.NewSymbol("#t"), ast.NewVariable("y")),
+		micro.EqualO(ast.NewSymbol("#f"), y),
+		micro.EqualO(ast.NewSymbol("#t"), y),
 	)()
 	ss := ifte(micro.EmptyState())
 	got := ss.String()
+	// reifying x and y; we assigned them a random uint64 and lost track of it
+	got = strings.Replace(got, "v10001", "x", -1)
+	got = strings.Replace(got, "v10002", "y", -1)
 	want := "(((,y . #f) (,x . #t) . 0))"
 	if got != want {
 		t.Fatalf("got %v != want %v", got, want)

--- a/sexpr/ast/ast.go
+++ b/sexpr/ast/ast.go
@@ -2,8 +2,14 @@ package ast
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
+	"time"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func Cons(car *SExpr, cdr *SExpr) *SExpr {
 	return &SExpr{Pair: &Pair{Car: car, Cdr: cdr}}
@@ -164,17 +170,23 @@ func ParseVariable(s string) (*SExpr, error) {
 }
 
 func NewVariable(s string) *SExpr {
+	return NewVar(s, rand.Uint64())
+}
+
+func NewVar(s string, i uint64) *SExpr {
 	return &SExpr{
 		Atom: &Atom{
 			Var: &Variable{
-				Name: s,
+				Name:  s,
+				Index: i,
 			},
 		},
 	}
 }
 
 type Variable struct {
-	Name string
+	Name  string
+	Index uint64
 }
 
 func (v *Variable) String() string {

--- a/sexpr/ast/derived.gen.go
+++ b/sexpr/ast/derived.gen.go
@@ -65,6 +65,7 @@ func deriveGoStringVar(this *Variable) string {
 	} else {
 		fmt.Fprintf(buf, "this := &ast.Variable{}\n")
 		fmt.Fprintf(buf, "this.Name = %#v\n", this.Name)
+		fmt.Fprintf(buf, "this.Index = %#v\n", this.Index)
 		fmt.Fprintf(buf, "return this\n")
 	}
 	fmt.Fprintf(buf, "}()\n")
@@ -83,7 +84,8 @@ func deriveEqual(this, that *SExpr) bool {
 func deriveEqualVar(this, that *Variable) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			this.Name == that.Name
+			this.Name == that.Name &&
+			this.Index == that.Index
 }
 
 // deriveGoString_ returns a recursive representation of this as a valid go string.


### PR DESCRIPTION
Makes everything a little faster, losing the ability to simply call Reify(varname string).
Which is totally in line with the 2013 ukanren paper but the parser is a bit more useless now.