### PR TITLE
fibonacci benchmarks

### DIFF
--- a/concurrent/fibonacci_test.go
+++ b/concurrent/fibonacci_test.go
@@ -1,0 +1,126 @@
+package concurrent
+
+import (
+	"testing"
+
+	"github.com/awalterschulze/gominikanren/micro"
+	"github.com/awalterschulze/gominikanren/mini"
+	"github.com/awalterschulze/gominikanren/sexpr/ast"
+)
+
+func benchFib(b *testing.B, num int, f func(...micro.Goal) micro.Goal) {
+	var r []*ast.SExpr
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		r = runFib(num, f)
+	}
+	result = r
+}
+
+func BenchmarkFib10SeqZzz(b *testing.B) {
+	benchFib(b, 10, mini.ConjPlus)
+}
+
+func BenchmarkFib10Seq(b *testing.B) {
+	benchFib(b, 10, mini.ConjPlusNoZzz)
+}
+
+func BenchmarkFib10ConcZzz(b *testing.B) {
+	benchFib(b, 10, ConjPlusZzz)
+}
+
+func BenchmarkFib10Conc(b *testing.B) {
+	benchFib(b, 10, ConjPlus)
+}
+func BenchmarkFib15SeqZzz(b *testing.B) {
+	benchFib(b, 15, mini.ConjPlus)
+}
+
+func BenchmarkFib15Seq(b *testing.B) {
+	benchFib(b, 15, mini.ConjPlusNoZzz)
+}
+
+func BenchmarkFib15ConcZzz(b *testing.B) {
+	benchFib(b, 15, ConjPlusZzz)
+}
+
+func BenchmarkFib15Conc(b *testing.B) {
+	benchFib(b, 15, ConjPlus)
+}
+
+// peano numbers and extralogical convenience functions
+var zero = ast.NewInt(0)
+var one = makenat(1)
+
+func succ(prev, next *ast.SExpr) micro.Goal {
+	return micro.EqualO(next, ast.Cons(prev, nil))
+}
+
+func makenat(n int) *ast.SExpr {
+	if n == 0 {
+		return zero
+	}
+	return ast.Cons(makenat(n-1), nil)
+}
+
+func parsenat(x *ast.SExpr) int {
+	if x == zero {
+		return 0
+	}
+	return parsenat(x.Car()) + 1
+}
+
+func toList(list []int) *ast.SExpr {
+	var out *ast.SExpr = nil
+	for i := 0; i < len(list); i++ {
+		out = ast.Cons(makenat(list[len(list)-i-1]), out)
+	}
+	return out
+}
+
+func natplus(x, y, z *ast.SExpr) micro.Goal {
+	return mini.Conde(
+		[]micro.Goal{micro.EqualO(x, zero), micro.EqualO(y, z)},
+		[]micro.Goal{
+			micro.CallFresh(func(a *ast.SExpr) micro.Goal {
+				return micro.CallFresh(func(b *ast.SExpr) micro.Goal {
+					return mini.ConjPlus(
+						succ(a, x),
+						succ(b, z),
+						natplus(a, y, b),
+					)
+				})
+			}),
+		},
+	)
+}
+
+func fib(conj func(...micro.Goal) micro.Goal, x, y *ast.SExpr) micro.Goal {
+	return mini.Conde(
+		[]micro.Goal{micro.EqualO(x, zero), micro.EqualO(y, zero)},
+		[]micro.Goal{micro.EqualO(x, one), micro.EqualO(y, one)},
+		[]micro.Goal{
+			micro.CallFresh(func(n1 *ast.SExpr) micro.Goal {
+				return micro.CallFresh(func(n2 *ast.SExpr) micro.Goal {
+					return micro.CallFresh(func(f1 *ast.SExpr) micro.Goal {
+						return micro.CallFresh(func(f2 *ast.SExpr) micro.Goal {
+							return conj(
+								succ(n1, x),
+								succ(n2, n1),
+								fib(conj, n1, f1),
+								fib(conj, n2, f2),
+								natplus(f1, f2, y),
+							)
+						})
+					})
+				})
+			}),
+		},
+	)
+}
+
+func runFib(n int, f func(...micro.Goal) micro.Goal) []*ast.SExpr {
+	return micro.Run(-1, func(q *ast.SExpr) micro.Goal {
+		return fib(f, makenat(n), q)
+	})
+}


### PR DESCRIPTION
Previous gains in concurrent fibonacci seem to have disappeared. I was seeing a lot of weird result; things made more sense when I ran benchmark with `p=1`. Cleaned up a race in benchmarks by passing the disj/conj funcs now.

Benchmarks currently:
```
go test ./... -bench=.
BenchmarkMembero10000-12             	       6	 170382961 ns/op
BenchmarkConcMembero10000-12         	       6	 175794696 ns/op
BenchmarkMembero50000-12             	       1	4712985422 ns/op
BenchmarkConcMembero50000-12         	       1	4664648870 ns/op
BenchmarkMapo10000-12                	       1	2614844021 ns/op
BenchmarkConcMapo10000-12            	       1	2573593390 ns/op
BenchmarkMapoFailHead10000-12        	       1	2587187449 ns/op
BenchmarkConcMapoFailHead10000-12    	       1	3039544651 ns/op
BenchmarkMapoFailTail10000-12        	       1	2584415515 ns/op
BenchmarkConcMapoFailTail10000-12    	       1	3051092403 ns/op
BenchmarkEinsteinSeqZzz-12           	       2	 762453454 ns/op
BenchmarkEinsteinSeq-12              	       3	 480798089 ns/op
BenchmarkEinsteinConcZzz-12          	       2	 848067872 ns/op
BenchmarkEinsteinConc-12             	       3	 425367135 ns/op
BenchmarkEinsteinConcNoOrder-12      	       3	 415359342 ns/op
BenchmarkFib10SeqZzz-12              	      57	  23192539 ns/op
BenchmarkFib10Seq-12                 	      64	  21799538 ns/op
BenchmarkFib10ConcZzz-12             	      57	  23752112 ns/op
BenchmarkFib10Conc-12                	      51	  29625355 ns/op
BenchmarkFib15SeqZzz-12              	       1	4007512714 ns/op
BenchmarkFib15Seq-12                 	       1	3582889230 ns/op
BenchmarkFib15ConcZzz-12             	       1	3717924170 ns/op
BenchmarkFib15Conc-12                	       1	6402106900 ns/op
```